### PR TITLE
fix: place_beam call in a for loop from client side fails - added - place_beam_list()

### DIFF
--- a/asyncroscopy/Microscope.py
+++ b/asyncroscopy/Microscope.py
@@ -371,6 +371,23 @@ class Microscope(Device, metaclass=CombinedMeta):
         """
         self._place_beam(position)
 
+    @command(dtype_in=DevVarFloatArray, dtype_out=None)
+    def place_beam_list(self, positions) -> None:
+        """
+        Place beam at multiple positions sequentially.
+        Extension of place_beam command 
+        Why not call  place_beam in loop of client side -> It fails
+        """
+        if len(positions) % 2 != 0:
+            raise ValueError("Input must contain pairs of (x, y) values.")
+
+        for i in range(0, len(positions), 2):
+            x = float(positions[i])
+            y = float(positions[i + 1])
+
+            self._place_beam([x, y])
+
+
     @command()
     def blank_beam(self) -> None:
         """blank beam"""


### PR DESCRIPTION

Fixes - https://github.com/pycroscopy/asyncroscopy/issues/74