### PR TITLE
added --config flag to scripts/run_servers.py

### DIFF
--- a/configs/Spectra300.yaml
+++ b/configs/Spectra300.yaml
@@ -1,0 +1,49 @@
+# Default asyncroscopy server config — Thermo Fisher Spectra 300 TEM.
+# Read by scripts/run_servers.py. Values here reproduce the script's historic
+# built-in defaults, so a headless start equals accepting every prompt.
+#
+#   uv run scripts/run_servers.py --yaml configs/Spectra300.yaml            # real, headless
+#   uv run scripts/run_servers.py --yaml configs/Spectra300.yaml --microscope dt
+
+microscope:
+  class_name: ThermoMicroscope
+  module_name: asyncroscopy.ThermoMicroscope
+  description: "Thermo Fisher Spectra 300 TEM"
+  host: 10.46.217.241        # AutoScript endpoint -> microscope's autoscript_host_ip / _port
+  port: 9095
+
+digital_twin:
+  class_name: DigitalTwin
+  module_name: asyncroscopy.DigitalTwin
+  description: "Software digital twin"
+  # No host/port: the bundled twin needs no AutoScript endpoint.
+
+# Support device servers. class_name defaults to the key upper-cased
+# (camera -> CAMERA); add `class_name:` to a device only to override that.
+devices:
+  camera:    { module_name: asyncroscopy.detectors.CAMERA }
+  corrector: { module_name: asyncroscopy.hardware.CORRECTOR }
+  data:      { module_name: asyncroscopy.software.DATA }
+  eds:       { module_name: asyncroscopy.detectors.EDS }
+  flucam:    { module_name: asyncroscopy.detectors.FLUCAM }
+  scan:      { module_name: asyncroscopy.hardware.SCAN }
+  stage:     { module_name: asyncroscopy.hardware.STAGE }
+
+tango:
+  host: 10.46.217.241
+  port: 9094
+
+tiled:
+  host: 10.46.217.241
+  port: 9091
+  acquisition_dir: outputs/tiled_acquisitions
+  autostart: true
+
+device_timeout_seconds: 120
+
+# Reserved for a future commit — run_servers.py does NOT start MCP yet.
+mcp:
+  autostart: false
+  class_name: ThermoMCP
+  http_host: 127.0.0.1
+  http_port: 8000

--- a/configs/ThinkPad-utkarsh-covalent-setup.yaml
+++ b/configs/ThinkPad-utkarsh-covalent-setup.yaml
@@ -1,0 +1,45 @@
+# Local test setup (utkarsh's ThinkPad) — everything on localhost.
+# Mirrors what was validated in issue #92: AutoScript on localhost:9095.
+#
+#   uv run scripts/run_servers.py --yaml configs/ThinkPad-utkarsh-covalent-setup.yaml
+
+microscope:
+  class_name: ThermoMicroscope
+  module_name: asyncroscopy.ThermoMicroscope
+  description: "Local Spectra 300 against a localhost AutoScript server"
+  host: localhost
+  port: 9095
+
+digital_twin:
+  class_name: DigitalTwin
+  module_name: asyncroscopy.DigitalTwin
+  description: "Software digital twin"
+  # No host/port: the bundled twin needs no AutoScript endpoint.
+
+devices:
+  camera:    { module_name: asyncroscopy.detectors.CAMERA }
+  corrector: { module_name: asyncroscopy.hardware.CORRECTOR }
+  data:      { module_name: asyncroscopy.software.DATA }
+  eds:       { module_name: asyncroscopy.detectors.EDS }
+  flucam:    { module_name: asyncroscopy.detectors.FLUCAM }
+  scan:      { module_name: asyncroscopy.hardware.SCAN }
+  stage:     { module_name: asyncroscopy.hardware.STAGE }
+
+tango:
+  host: localhost
+  port: 9094
+
+tiled:
+  host: localhost
+  port: 9091
+  acquisition_dir: outputs/tiled_acquisitions
+  autostart: true
+
+device_timeout_seconds: 120
+
+# Reserved for a future commit — run_servers.py does NOT start MCP yet.
+mcp:
+  autostart: false
+  class_name: ThermoMCP
+  http_host: 127.0.0.1
+  http_port: 8000

--- a/docs/Operation/run-servers.md
+++ b/docs/Operation/run-servers.md
@@ -10,8 +10,13 @@ defaults, then stays running so you can use the servers.
 ## TL;DR
 
 ```bash
-uv run scripts/run_servers.py            # real microscope (ThermoMicroscope)
-uv run scripts/run_servers.py --microscope dt   # digital twin (DigitalTwin)
+uv run scripts/run_servers.py            # real microscope (ThermoMicroscope), interactive prompts
+uv run scripts/run_servers.py --microscope dt   # digital twin (DigitalTwin), interactive prompts
+
+# Headless: start straight from a YAML config, no prompts (see "Configs" below)
+uv run scripts/run_servers.py --yaml configs/Spectra300.yaml
+uv run scripts/run_servers.py --yaml configs\ThinkPad-utkarsh-covalent-setup.yaml
+uv run scripts/run_servers.py --yaml configs/Spectra300.yaml --microscope dt
 ```
 
 - Press **Enter** at every prompt to accept the value in `[brackets]`.
@@ -32,9 +37,37 @@ The microscope is started last and given the addresses of the support devices as
 database properties, so it can find them via `DeviceProxy`. In `real` mode it
 also receives the AutoScript host/port.
 
+## Configs (`--yaml`)
+
+The script's startup values — which devices to launch, the microscope class, and
+the hosts/ports/paths — live in a YAML file under [configs/](../../configs). Two
+ship today:
+
+| File | For |
+|------|-----|
+| [configs/Spectra300.yaml](../../configs/Spectra300.yaml) | The real Spectra 300 (the default config). |
+| [configs/ThinkPad-utkarsh-covalent-setup.yaml](../../configs/ThinkPad-utkarsh-covalent-setup.yaml) | A localhost-everywhere setup for local testing. |
+
+Each file has a `microscope:` block (real) and an optional `digital_twin:` block;
+`--microscope {real,dt}` chooses between them. Device `class_name` defaults to the
+key upper-cased (`scan` → `SCAN`). A `microscope.host`/`port` becomes the
+microscope's `autoscript_host_ip`/`_port`. The `mcp:` block is reserved — the
+script does not start MCP yet.
+
+**Two ways to run:**
+
+- **Interactive** (no `--yaml`): the bundled default config seeds the prompt
+  defaults; you confirm or override each at the prompt.
+- **Headless** (`--yaml <file>`): no prompts — the file is the single source of
+  truth (clear/start-DB/register all run; Tiled follows `tiled.autostart`). This
+  is the path the GUI will use.
+
+To make your own, copy `Spectra300.yaml` and edit the hosts/ports/devices.
+
 ## The prompts
 
-Answered top to bottom; defaults shown are the script's built-ins.
+Used only in interactive mode (no `--yaml`). Answered top to bottom; the defaults
+shown come from the active config (`configs/Spectra300.yaml` unless overridden).
 
 | Prompt | Default | What it controls |
 |--------|---------|------------------|
@@ -79,8 +112,9 @@ The run prints progress as five sections:
 - **Tiled failed to start.** Check the save path is writable and the Tiled port
   is free; the failure message comes from the `data` device.
 
-> Not yet implemented (see TODOs in the script): alternate configs as `.yaml`
-> files and a `--debug` flag to stream every server's output live.
+> Not yet implemented (see TODO in the script): a `--debug` flag to stream every
+> server's output live. Alternate configs as `.yaml` files are now supported —
+> see [Configs](#configs---yaml) above.
 
 ## What it does under the hood (manual fallback)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,13 +28,14 @@ dependencies = [
     # AutoScript (local wheels)
     "autoscript-core",
     "autoscript-tem-microscope-client",
-#    "autoscript-tem-microscope-client-tests", -> version 1.17 doesnt have this
-#    "autoscript-tem-snippets-tests", -> version 1.17 doesnt have this
+    #    "autoscript-tem-microscope-client-tests", -> version 1.17 doesnt have this
+    #    "autoscript-tem-snippets-tests", -> version 1.17 doesnt have this
     "autoscript-tem-toolkit",
     "thermoscientific-logging",
     "aicspylibczi>=3.3.1",
     "jupyter-book>=2.0.0",
     "tiled[all]>=0.2.9",
+    "pyyaml>=6.0.3",
 ]
 
 [tool.setuptools]

--- a/scripts/run_servers.py
+++ b/scripts/run_servers.py
@@ -16,26 +16,20 @@ from typing import Iterable
 from urllib.parse import urlsplit
 
 import tango
+import yaml
 
 
-DEFAULT_TANGO_HOST = "10.46.217.241"
-DEFAULT_TANGO_PORT = 9094
-DEFAULT_TILED_URI = "http://10.46.217.241:9091"
-DEFAULT_ACQUISITION_DIR = "outputs/tiled_acquisitions"
 DATABASE_TIMEOUT_SECONDS = 120
-DEVICE_TIMEOUT_SECONDS = 120
 TILED_COMMAND_TIMEOUT_MILLIS = 120_000
-
-# AutoScript connection defaults — must match ThermoMicroscope's device_property
-# fallbacks so that accepting the prompts reproduces today's behaviour. Override
-# at the prompt to point at a simulator (e.g. localhost:7521).
-DEFAULT_AUTOSCRIPT_HOST = "10.46.217.241"
-DEFAULT_AUTOSCRIPT_PORT = 9095
 
 PROJECT_DIR = Path(__file__).resolve().parents[1]
 
 if str(PROJECT_DIR) not in sys.path:
     sys.path.insert(0, str(PROJECT_DIR))
+
+# Default config used in interactive mode (no --yaml). Passing --yaml <file>
+# selects a different config AND runs headlessly (no prompts).
+DEFAULT_CONFIG_PATH = PROJECT_DIR / "configs" / "Spectra300.yaml"
 
 
 class Style:
@@ -88,89 +82,140 @@ class ManagedProcess:
     def running(self) -> bool:
         return self.process.poll() is None
 
-# TODO: Break out alternate configs into .yaml files or somthing
-# TODO: ex. UTKSpectra300.yaml, DigitatlTwin.yaml, WDTwin.yaml
-# TODO: --debug flag where all the terminal outputs of the servers show in this termainl (or are saved to file)
-
-MICROSCOPE_MODES = {
-    "real": ("ThermoMicroscope", "asyncroscopy.ThermoMicroscope"),
-    "dt": ("DigitalTwin", "asyncroscopy.DigitalTwin"),
-}
-
-SUPPORT_DEVICES = [
-    DeviceConfig(
-        key="camera",
-        class_name="CAMERA",
-        module_name="asyncroscopy.detectors.CAMERA",
-    ),
-    DeviceConfig(
-        key="corrector",
-        class_name="CORRECTOR",
-        module_name="asyncroscopy.hardware.CORRECTOR",
-    ),
-    DeviceConfig(
-        key="data",
-        class_name="DATA",
-        module_name="asyncroscopy.software.DATA",
-    ),
-    DeviceConfig(
-        key="eds",
-        class_name="EDS",
-        module_name="asyncroscopy.detectors.EDS",
-    ),
-    DeviceConfig(
-        key="flucam",
-        class_name="FLUCAM",
-        module_name="asyncroscopy.detectors.FLUCAM",
-    ),
-    DeviceConfig(
-        key="scan",
-        class_name="SCAN",
-        module_name="asyncroscopy.hardware.SCAN",
-    ),
-    DeviceConfig(
-        key="stage",
-        class_name="STAGE",
-        module_name="asyncroscopy.hardware.STAGE",
-    ),
-]
+# TODO: --debug flag where all server output streams to this terminal / log files (next commit).
 
 
-def build_devices(microscope_mode: str) -> list[DeviceConfig]:
-    microscope_class, microscope_module = MICROSCOPE_MODES[microscope_mode]
+@dataclass(frozen=True)
+class MicroscopeConfig:
+    class_name: str
+    module_name: str
+    description: str = ""
+    host: str | None = None
+    port: int | None = None
+
+
+@dataclass(frozen=True)
+class TiledConfig:
+    host: str
+    port: int
+    acquisition_dir: str
+    autostart: bool = True
+
+
+@dataclass(frozen=True)
+class Config:
+    path: Path
+    microscope: MicroscopeConfig
+    digital_twin: MicroscopeConfig | None
+    support_devices: list[DeviceConfig]
+    tango_host: str
+    tango_port: int
+    tiled: TiledConfig
+    device_timeout_seconds: int
+
+
+def _require(mapping, key: str, where: str):
+    if not isinstance(mapping, dict) or key not in mapping:
+        raise KeyError(f"Config section '{where}' is missing required key '{key}'")
+    return mapping[key]
+
+
+def _microscope_config(raw: dict) -> MicroscopeConfig:
+    return MicroscopeConfig(
+        class_name=_require(raw, "class_name", "microscope"),
+        module_name=_require(raw, "module_name", "microscope"),
+        description=raw.get("description", ""),
+        host=raw.get("host"),
+        port=raw.get("port"),
+    )
+
+
+def load_config(path: Path) -> Config:
+    if not path.exists():
+        raise FileNotFoundError(f"Config file not found: {path}")
+    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+
+    support_devices = [
+        DeviceConfig(
+            key=key,
+            class_name=(spec or {}).get("class_name", key.upper()),
+            module_name=_require(spec or {}, "module_name", f"devices.{key}"),
+        )
+        for key, spec in _require(raw, "devices", "(top level)").items()
+    ]
+    digital_twin = raw.get("digital_twin")
+    tango_section = raw.get("tango", {})
+    tiled = _require(raw, "tiled", "(top level)")
+
+    return Config(
+        path=path,
+        microscope=_microscope_config(_require(raw, "microscope", "(top level)")),
+        digital_twin=_microscope_config(digital_twin) if digital_twin else None,
+        support_devices=support_devices,
+        tango_host=_require(tango_section, "host", "tango"),
+        tango_port=int(_require(tango_section, "port", "tango")),
+        tiled=TiledConfig(
+            host=_require(tiled, "host", "tiled"),
+            port=int(_require(tiled, "port", "tiled")),
+            acquisition_dir=_require(tiled, "acquisition_dir", "tiled"),
+            autostart=bool(tiled.get("autostart", True)),
+        ),
+        device_timeout_seconds=int(raw.get("device_timeout_seconds", 120)),
+    )
+
+
+def selected_microscope_config(config: Config, mode: str) -> MicroscopeConfig:
+    if mode == "dt":
+        if config.digital_twin is None:
+            raise ValueError(f"{config.path} has no 'digital_twin' block (needed for --microscope dt)")
+        return config.digital_twin
+    return config.microscope
+
+
+def build_devices(config: Config, mode: str) -> list[DeviceConfig]:
+    micro = selected_microscope_config(config, mode)
     return [
-        *SUPPORT_DEVICES,
+        *config.support_devices,
         DeviceConfig(
             key="microscope",
-            class_name=microscope_class,
-            module_name=microscope_module,
+            class_name=micro.class_name,
+            module_name=micro.module_name,
             start_after_dependencies=True,
         ),
     ]
 
 
-DEVICES = build_devices("real")
-
-MICROSCOPE_DEVICE_KEYS = ("scan", "camera", "flucam", "eds", "stage", "corrector", "data")
-MICROSCOPE_PROPERTIES = {
-    f"{device_key}_device_address": [f"asyncroscopy/{device_key}/default"]
-    for device_key in MICROSCOPE_DEVICE_KEYS
-}
+def device_address_properties(config: Config) -> dict[str, list[str]]:
+    return {
+        f"{device.key}_device_address": [device.device_name]
+        for device in config.support_devices
+    }
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--microscope",
-        choices=sorted(MICROSCOPE_MODES),
+        choices=["real", "dt"],
         default="real",
-        help="Microscope backend to start. Defaults to real.",
+        help="Which block to start: 'real' microscope or 'dt' digital twin. Defaults to real.",
+    )
+    parser.add_argument(
+        "--yaml",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help="YAML config to start from. When given, runs headlessly (no prompts). "
+        "When omitted, uses the bundled default config and prompts interactively.",
     )
     return parser.parse_args(argv)
 
 
-def all_microscope_cleanup_patterns() -> set[str]:
-    return {f"{class_name} microscope_instance" for class_name, _ in MICROSCOPE_MODES.values()}
+def all_microscope_cleanup_patterns(config: Config) -> set[str]:
+    classes = {config.microscope.class_name}
+    if config.digital_twin is not None:
+        classes.add(config.digital_twin.class_name)
+    return {f"{class_name} microscope_instance" for class_name in classes}
 
 
 def selected_microscope(devices: list[DeviceConfig]) -> DeviceConfig:
@@ -379,7 +424,7 @@ def stop_python_process_matching(pattern: str) -> bool:
     return result.returncode == 0
 
 
-def clear_old_processes(port: int, devices: list[DeviceConfig], tiled_port: int | None = None) -> None:
+def clear_old_processes(port: int, devices: list[DeviceConfig], config: Config, tiled_port: int | None = None) -> None:
     stopped_databases = stop_processes_on_port(port)
     status_line("OK" if stopped_databases else "SKIP", f"database port {port}", f"{stopped_databases} process(es) signaled")
 
@@ -389,7 +434,7 @@ def clear_old_processes(port: int, devices: list[DeviceConfig], tiled_port: int 
 
     stopped_servers = 0
     cleanup_patterns = {f"{device.class_name} {device.instance_name}" for device in devices}
-    cleanup_patterns.update(all_microscope_cleanup_patterns())
+    cleanup_patterns.update(all_microscope_cleanup_patterns(config))
     for pattern in sorted(cleanup_patterns):
         if stop_python_process_matching(pattern):
             stopped_servers += 1
@@ -509,33 +554,54 @@ def main(argv: list[str] | None = None) -> int:
         signal.signal(signal.SIGHUP, request_shutdown)
 
     args = parse_args(argv)
-    devices = build_devices(args.microscope)
+    config_path = args.yaml or DEFAULT_CONFIG_PATH
+    try:
+        config = load_config(config_path)
+    except (FileNotFoundError, KeyError, ValueError) as exc:
+        print(color(f"Config error: {exc}", Style.bold + Style.red))
+        return 1
+
+    headless = args.yaml is not None
+    devices = build_devices(config, args.microscope)
     microscope = selected_microscope(devices)
+    micro_config = selected_microscope_config(config, args.microscope)
     regular_devices = [device for device in devices if not device.start_after_dependencies]
     dependency_devices = [device for device in devices if device.start_after_dependencies]
 
     print_banner("ASYNCROSCOPY SERVER STARTUP")
-    print("Press Enter at any prompt to use the value shown in brackets.")
-    print()
 
-    host = prompt_str("Tango database host", DEFAULT_TANGO_HOST)
-    port = prompt_int("Tango database port", DEFAULT_TANGO_PORT)
-    default_tiled = urlsplit(os.environ.get("ASYNCROSCOPY_TILED_URI", DEFAULT_TILED_URI))
-    tiled_host = prompt_str("Tiled HTTP host", default_tiled.hostname or host)
-    tiled_port = prompt_int("Tiled HTTP port", default_tiled.port or 9091)
-    acquisition_dir = prompt_str("Acquisition save path", os.environ.get("ASYNCROSCOPY_ACQUISITION_DIR", DEFAULT_ACQUISITION_DIR))
-    should_start_tiled = prompt_bool("Start Tiled HTTP server", True)
-    clear_first = prompt_bool("Clear old processes first", True)
-    start_database = prompt_bool("Start Tango database", True)
-    should_register_devices = prompt_bool("Register devices", True)
-    device_timeout = prompt_int("Device startup timeout seconds", DEVICE_TIMEOUT_SECONDS)
-
-    microscope_properties = dict(MICROSCOPE_PROPERTIES)
-    if args.microscope == "real":
-        autoscript_host = prompt_str("AutoScript host IP", DEFAULT_AUTOSCRIPT_HOST)
-        autoscript_port = prompt_int("AutoScript host port", DEFAULT_AUTOSCRIPT_PORT)
-        microscope_properties["autoscript_host_ip"] = [autoscript_host]
-        microscope_properties["autoscript_host_port"] = [str(autoscript_port)]
+    microscope_properties = device_address_properties(config)
+    if headless:
+        print(f"Headless start from {config_path}")
+        print()
+        host, port = config.tango_host, config.tango_port
+        tiled_host, tiled_port = config.tiled.host, config.tiled.port
+        acquisition_dir = config.tiled.acquisition_dir
+        should_start_tiled = config.tiled.autostart
+        clear_first = start_database = should_register_devices = True
+        device_timeout = config.device_timeout_seconds
+        if micro_config.host is not None and micro_config.port is not None:
+            microscope_properties["autoscript_host_ip"] = [str(micro_config.host)]
+            microscope_properties["autoscript_host_port"] = [str(micro_config.port)]
+    else:
+        print("Press Enter at any prompt to use the value shown in brackets.")
+        print()
+        host = prompt_str("Tango database host", config.tango_host)
+        port = prompt_int("Tango database port", config.tango_port)
+        default_tiled = urlsplit(os.environ.get("ASYNCROSCOPY_TILED_URI", f"http://{config.tiled.host}:{config.tiled.port}"))
+        tiled_host = prompt_str("Tiled HTTP host", default_tiled.hostname or config.tiled.host)
+        tiled_port = prompt_int("Tiled HTTP port", default_tiled.port or config.tiled.port)
+        acquisition_dir = prompt_str("Acquisition save path", os.environ.get("ASYNCROSCOPY_ACQUISITION_DIR", config.tiled.acquisition_dir))
+        should_start_tiled = prompt_bool("Start Tiled HTTP server", config.tiled.autostart)
+        clear_first = prompt_bool("Clear old processes first", True)
+        start_database = prompt_bool("Start Tango database", True)
+        should_register_devices = prompt_bool("Register devices", True)
+        device_timeout = prompt_int("Device startup timeout seconds", config.device_timeout_seconds)
+        if micro_config.host is not None and micro_config.port is not None:
+            autoscript_host = prompt_str("AutoScript host IP", str(micro_config.host))
+            autoscript_port = prompt_int("AutoScript host port", int(micro_config.port))
+            microscope_properties["autoscript_host_ip"] = [autoscript_host]
+            microscope_properties["autoscript_host_port"] = [str(autoscript_port)]
 
     environment = make_environment(host, port, tiled_host, tiled_port, acquisition_dir)
     processes: list[ManagedProcess] = []
@@ -545,13 +611,14 @@ def main(argv: list[str] | None = None) -> int:
     print()
     print(f"  {color('TANGO_HOST', Style.bold):<18} {host}:{port}")
     print(f"  {color('PROJECT', Style.bold):<18} {PROJECT_DIR}")
+    print(f"  {color('CONFIG', Style.bold):<18} {config_path}")
     print(f"  {color('MICROSCOPE', Style.bold):<18} {args.microscope} ({microscope.class_name})")
     print_inventory(devices)
 
     try:
         print_section(1, 5, "Clearing old processes")
         if clear_first:
-            clear_old_processes(port, devices, tiled_port if should_start_tiled else None)
+            clear_old_processes(port, devices, config, tiled_port if should_start_tiled else None)
         else:
             status_line("SKIP", "old process cleanup")
 


### PR DESCRIPTION
See -> https://github.com/pycroscopy/asyncroscopy/issues/92

What changed?:
- New: [configs/Spectra300.yaml](vscode-webview://088vtjjkncjjdt55so85nistiauggf1tbr0jlp8h4ted3h38eiq1/configs/Spectra300.yaml), [configs/ThinkPad-utkarsh-covalent-setup.yaml](vscode-webview://088vtjjkncjjdt55so85nistiauggf1tbr0jlp8h4ted3h38eiq1/configs/ThinkPad-utkarsh-covalent-setup.yaml)
- Edited: scripts/run_servers.py --> added --yaml  flag

Q. Updated docs?
- Yes: updated -> docs\Operation\run-servers.md
- Configs section, headless examples, flipped the not-implemented note


Q. Did you do a smoke test?
- Yes I did:  `uv run scripts/run_servers.py --yaml configs\ThinkPad-utkarsh-covalent-setup.yaml`
- Works great!