### PR TITLE
Adding aperture control support for AutoScript microscope workflows

### DIFF
--- a/asyncroscopy/instruments/electron_microscope/adapters/__init__.py
+++ b/asyncroscopy/instruments/electron_microscope/adapters/__init__.py
@@ -1,0 +1,5 @@
+"""Vendor adapter layers for electron microscope hardware APIs."""
+
+from .autoscript_apertures import AutoScriptApertureAdapter
+
+__all__ = ["AutoScriptApertureAdapter"]

--- a/asyncroscopy/instruments/electron_microscope/adapters/autoscript_apertures.py
+++ b/asyncroscopy/instruments/electron_microscope/adapters/autoscript_apertures.py
@@ -1,0 +1,311 @@
+"""Isolated adapter for the documented AutoScript motorized-aperture API.
+
+The adapter accepts an already-connected microscope client.  It neither
+imports nor constructs ``TemMicroscopeClient``, so importing asyncroscopy and
+testing this module never requires an AutoScript installation or connection.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from asyncroscopy.instruments.electron_microscope.hardware.aperture import ApertureInfo
+
+
+class AutoScriptApertureAdapter:
+    """Translate AutoScript aperture objects into vendor-neutral models."""
+
+    def __init__(self, microscope: Any) -> None:
+        if microscope is None:
+            raise ValueError("An existing AutoScript microscope object is required.")
+        self._microscope = microscope
+
+    @staticmethod
+    def _missing(path: str) -> RuntimeError:
+        return RuntimeError(f"Missing AutoScript object/property: {path}")
+
+    @staticmethod
+    def _unsupported(operation: str, path: str) -> RuntimeError:
+        return RuntimeError(
+            f"Unsupported AutoScript aperture operation {operation!r}: "
+            f"missing documented object/property {path}."
+        )
+
+    @classmethod
+    def _require_attribute(cls, owner: Any, name: str, path: str) -> Any:
+        try:
+            return getattr(owner, name)
+        except AttributeError as exc:
+            raise cls._missing(path) from exc
+
+    @classmethod
+    def _require_method(cls, owner: Any, name: str, path: str):
+        method = cls._require_attribute(owner, name, path)
+        if not callable(method):
+            raise cls._missing(path)
+        return method
+
+    def _collection(self) -> Any:
+        optics = self._require_attribute(
+            self._microscope,
+            "optics",
+            "microscope.optics",
+        )
+        return self._require_attribute(
+            optics,
+            "aperture_mechanisms",
+            "microscope.optics.aperture_mechanisms",
+        )
+
+    def list_mechanisms(self) -> list[str]:
+        """Return mechanism identifiers reported by AutoScript."""
+        collection = self._collection()
+        get_available = self._require_method(
+            collection,
+            "get_available",
+            "microscope.optics.aperture_mechanisms.get_available",
+        )
+        return list(get_available())
+
+    def _mechanism(self, mechanism: str) -> Any:
+        available = self.list_mechanisms()
+        if mechanism not in available:
+            names = ", ".join(available)
+            raise ValueError(
+                f"Unknown AutoScript aperture mechanism {mechanism!r}. "
+                f"Available mechanisms: {names}."
+            )
+
+        collection = self._collection()
+        get_mechanism = self._require_method(
+            collection,
+            "get_mechanism",
+            "microscope.optics.aperture_mechanisms.get_mechanism",
+        )
+        return get_mechanism(mechanism)
+
+    @classmethod
+    def _aperture_info(
+        cls,
+        mechanism: str,
+        aperture: Any,
+        *,
+        inserted: bool | None,
+        selected: bool,
+    ) -> ApertureInfo:
+        name = cls._require_attribute(aperture, "name", "Aperture.name")
+        aperture_type = cls._require_attribute(aperture, "type", "Aperture.type")
+        diameter = cls._require_attribute(aperture, "diameter", "Aperture.diameter")
+        return ApertureInfo(
+            mechanism=mechanism,
+            name=name,
+            aperture_type=aperture_type,
+            diameter_m=float(diameter) if diameter is not None else None,
+            inserted=inserted,
+            selected=selected,
+        )
+
+    @staticmethod
+    def _inserted_from_state(insertion_state: str) -> bool | None:
+        if insertion_state == "Inserted":
+            return True
+        if insertion_state == "Retracted":
+            return False
+        return None
+
+    def list_apertures(self, mechanism: str) -> list[ApertureInfo]:
+        """Return all apertures on one discovered mechanism."""
+        mechanism_object = self._mechanism(mechanism)
+        apertures = self._require_attribute(
+            mechanism_object,
+            "apertures",
+            "ApertureMechanism.apertures",
+        )
+        selected_aperture = self._require_attribute(
+            mechanism_object,
+            "aperture",
+            "ApertureMechanism.aperture",
+        )
+        insertion_state = self.get_insertion_state(mechanism)
+        inserted = self._inserted_from_state(insertion_state)
+        selected_name = (
+            self._require_attribute(selected_aperture, "name", "Aperture.name")
+            if selected_aperture is not None
+            else None
+        )
+        return [
+            self._aperture_info(
+                mechanism,
+                aperture,
+                inserted=inserted,
+                selected=self._require_attribute(aperture, "name", "Aperture.name")
+                == selected_name,
+            )
+            for aperture in apertures
+        ]
+
+    def get_selected_aperture(self, mechanism: str) -> ApertureInfo:
+        """Return the selected aperture or fail clearly when none is selected."""
+        mechanism_object = self._mechanism(mechanism)
+        aperture = self._require_attribute(
+            mechanism_object,
+            "aperture",
+            "ApertureMechanism.aperture",
+        )
+        if aperture is None:
+            raise RuntimeError(
+                f"AutoScript ApertureMechanism.aperture is None for {mechanism!r}."
+            )
+        inserted = self._inserted_from_state(self.get_insertion_state(mechanism))
+        return self._aperture_info(
+            mechanism,
+            aperture,
+            inserted=inserted,
+            selected=True,
+        )
+
+    def select_aperture(self, mechanism: str, name: str) -> ApertureInfo:
+        """Select an AutoScript aperture by its documented unique name."""
+        mechanism_object = self._mechanism(mechanism)
+        apertures = self._require_attribute(
+            mechanism_object,
+            "apertures",
+            "ApertureMechanism.apertures",
+        )
+        selected = next(
+            (
+                aperture
+                for aperture in apertures
+                if self._require_attribute(aperture, "name", "Aperture.name") == name
+            ),
+            None,
+        )
+        if selected is None:
+            available = ", ".join(
+                self._require_attribute(aperture, "name", "Aperture.name")
+                for aperture in apertures
+            )
+            raise ValueError(
+                f"Unknown aperture name {name!r} for mechanism {mechanism!r}. "
+                f"Available apertures: {available}."
+            )
+        try:
+            mechanism_object.aperture = selected
+        except AttributeError as exc:
+            raise self._missing("ApertureMechanism.aperture") from exc
+        return self.get_selected_aperture(mechanism)
+
+    def get_insertion_state(self, mechanism: str) -> str:
+        """Return the documented AutoScript insertion-state string."""
+        mechanism_object = self._mechanism(mechanism)
+        return self._require_attribute(
+            mechanism_object,
+            "insertion_state",
+            "ApertureMechanism.insertion_state",
+        )
+
+    def is_enabled(self, mechanism: str) -> bool:
+        """Return documented `ApertureMechanism.is_enabled` status."""
+        mechanism_object = self._mechanism(mechanism)
+        try:
+            return bool(
+                self._require_attribute(
+                    mechanism_object,
+                    "is_enabled",
+                    "ApertureMechanism.is_enabled",
+                )
+            )
+        except RuntimeError as exc:
+            raise self._unsupported(
+                "is_enabled",
+                "ApertureMechanism.is_enabled",
+            ) from exc
+
+    def is_retractable(self, mechanism: str) -> bool:
+        """Return documented `ApertureMechanism.is_retractable` status."""
+        mechanism_object = self._mechanism(mechanism)
+        try:
+            return bool(
+                self._require_attribute(
+                    mechanism_object,
+                    "is_retractable",
+                    "ApertureMechanism.is_retractable",
+                )
+            )
+        except RuntimeError as exc:
+            raise self._unsupported(
+                "is_retractable",
+                "ApertureMechanism.is_retractable",
+            ) from exc
+
+    def enable(self, mechanism: str) -> bool:
+        """Call documented ``ApertureMechanism.enable()`` and return enabled state."""
+        mechanism_object = self._mechanism(mechanism)
+        try:
+            enable = self._require_method(
+                mechanism_object,
+                "enable",
+                "ApertureMechanism.enable",
+            )
+        except RuntimeError as exc:
+            raise self._unsupported("enable", "ApertureMechanism.enable") from exc
+        enable()
+        return self.is_enabled(mechanism)
+
+    def disable(self, mechanism: str) -> bool:
+        """Call documented ``ApertureMechanism.disable()`` and return enabled state."""
+        mechanism_object = self._mechanism(mechanism)
+        try:
+            disable = self._require_method(
+                mechanism_object,
+                "disable",
+                "ApertureMechanism.disable",
+            )
+        except RuntimeError as exc:
+            raise self._unsupported("disable", "ApertureMechanism.disable") from exc
+        disable()
+        return self.is_enabled(mechanism)
+    def insert_mechanism(self, mechanism: str) -> str:
+        """Call ``ApertureMechanism.insert()`` and return its resulting state."""
+        mechanism_object = self._mechanism(mechanism)
+        insert = self._require_method(
+            mechanism_object,
+            "insert",
+            "ApertureMechanism.insert",
+        )
+        insert()
+        return self.get_insertion_state(mechanism)
+
+    def retract_mechanism(self, mechanism: str) -> str:
+        """Call ``ApertureMechanism.retract()`` and return its resulting state."""
+        mechanism_object = self._mechanism(mechanism)
+        retract = self._require_method(
+            mechanism_object,
+            "retract",
+            "ApertureMechanism.retract",
+        )
+        retract()
+        return self.get_insertion_state(mechanism)
+
+    def get_position(self, mechanism: str) -> tuple[float, float] | None:
+        """Return documented selected-aperture position in meters."""
+        mechanism_object = self._mechanism(mechanism)
+        position = self._require_attribute(
+            mechanism_object,
+            "position",
+            "ApertureMechanism.position",
+        )
+        if position is None:
+            return None
+        x = self._require_attribute(position, "x", "Point.x")
+        y = self._require_attribute(position, "y", "Point.y")
+        return float(x), float(y)
+
+    def set_position(self, mechanism: str, x: float, y: float) -> tuple[float, float] | None:
+        """Set documented selected-aperture position with an ``(x, y)`` tuple."""
+        mechanism_object = self._mechanism(mechanism)
+        try:
+            mechanism_object.position = (float(x), float(y))
+        except AttributeError as exc:
+            raise self._missing("ApertureMechanism.position") from exc
+        return self.get_position(mechanism)

--- a/asyncroscopy/instruments/electron_microscope/auto_script.py
+++ b/asyncroscopy/instruments/electron_microscope/auto_script.py
@@ -16,9 +16,10 @@ Real AutoScript image commands save the adorned object on disk and return the
 DATA/Tiled unique id for that saved acquisition.
 """
 
+import json
 import math
 import time
-import json
+from typing import Any
 
 import numpy as np
 import tango
@@ -26,6 +27,13 @@ from tango import AttrWriteType, DevState
 from tango.server import attribute, command, device_property
 
 from asyncroscopy.instruments.electron_microscope.electron_microscope import ElectronMicroscope
+from asyncroscopy.instruments.electron_microscope.adapters.autoscript_apertures import (
+    AutoScriptApertureAdapter,
+)
+from asyncroscopy.instruments.electron_microscope.hardware.aperture import (
+    ApertureInfo,
+    SimulatedApertureBackend,
+)
 from asyncroscopy.data.data_writer import DEFAULT_ACQUISITION_DIR, save_acquisition
 
 # AutoScript imports — only available on the microscope PC.
@@ -148,7 +156,9 @@ class AutoScriptMicroscope(ElectronMicroscope):
     # ------------------------------------------------------------------
 
     def _connect(self):
+        self._aperture_logging_ready = True
         self._connect_hardware()
+        self._configure_aperture_adapter()
         self._connect_detector_proxies()
         self.set_state(DevState.ON)
         self.screen_current_calibration = None
@@ -157,6 +167,8 @@ class AutoScriptMicroscope(ElectronMicroscope):
         """Establish AutoScript connection from MPC -> hardware."""
         if not _AUTOSCRIPT_AVAILABLE or self.testing_mode_bool:
             self.warn_stream("AutoScript not available")
+            self._microscope = None
+            self.is_autoscript = False
             return
         try:
             self._microscope = TemMicroscopeClient()
@@ -168,6 +180,17 @@ class AutoScriptMicroscope(ElectronMicroscope):
             self.set_state(DevState.FAULT)
             self._microscope = None
             self.is_autoscript = False
+
+    def _configure_aperture_adapter(self) -> None:
+        """Select the real adapter only for a successful AutoScript connection."""
+        if self._microscope is not None and getattr(self, "is_autoscript", False):
+            self._aperture_adapter = AutoScriptApertureAdapter(self._microscope)
+            self._aperture_autoscript_available = True
+            self.info_stream("AutoScript aperture adapter initialised")
+        else:
+            self._aperture_adapter = SimulatedApertureBackend()
+            self._aperture_autoscript_available = False
+            self.info_stream("Simulated aperture backend initialised")
 
     def _connect_detector_proxies(self) -> None:
         """Build DeviceProxy objects for each configured detector device."""
@@ -245,6 +268,449 @@ class AutoScriptMicroscope(ElectronMicroscope):
         """
         self._get_stage()
 
+    @staticmethod
+    def _parse_aperture_request(
+        json_request: str,
+        *,
+        require_mechanism: bool,
+        require_name: bool = False,
+    ) -> dict:
+        try:
+            request = json.loads(json_request or "{}")
+        except (json.JSONDecodeError, TypeError) as exc:
+            raise ValueError("Invalid JSON request.") from exc
+        if not isinstance(request, dict):
+            raise ValueError("Aperture request must be a JSON object.")
+
+        mechanism = request.get("mechanism")
+        if require_mechanism and (not isinstance(mechanism, str) or not mechanism):
+            raise ValueError("Aperture request requires a non-empty string 'mechanism'.")
+        if mechanism is not None and not isinstance(mechanism, str):
+            raise ValueError("Aperture request field 'mechanism' must be a string.")
+
+        name = request.get("name")
+        if require_name and (not isinstance(name, str) or not name):
+            raise ValueError("Aperture request requires a non-empty string 'name'.")
+        if name is not None and not isinstance(name, str):
+            raise ValueError("Aperture request field 'name' must be a string.")
+        return request
+
+    @staticmethod
+    def _aperture_response_data(aperture: ApertureInfo | None) -> dict | None:
+        if aperture is None:
+            return None
+        return {
+            "name": aperture.name,
+            "type": aperture.aperture_type,
+            "diameter_m": aperture.diameter_m,
+        }
+
+    def _aperture_response(
+        self,
+        *,
+        ok: bool,
+        action: str,
+        mechanism: str,
+        aperture: ApertureInfo | None = None,
+        insertion_state: str | None = None,
+        error: str | None = None,
+        **extra,
+    ) -> str:
+        payload = {
+            "ok": ok,
+            "action": action,
+            "mechanism": mechanism,
+            "aperture": self._aperture_response_data(aperture),
+            "insertion_state": insertion_state,
+            "autoscript_available": self._aperture_autoscript_available,
+            "error": error,
+        }
+        payload.update(extra)
+        return json.dumps(payload, sort_keys=True, separators=(",", ":"), allow_nan=False)
+
+    def _aperture_error(self, action: str, mechanism: str, exc: Exception) -> str:
+        message = str(exc)
+        self.error_stream(
+            f"Aperture action failed: action={action}, mechanism={mechanism!r}, error={message}"
+        )
+        return self._aperture_response(
+            ok=False,
+            action=action,
+            mechanism=mechanism,
+            error=message,
+        )
+
+    def _require_aperture_enabled(self, mechanism: str, action: str) -> None:
+        try:
+            enabled = self._aperture_adapter.is_enabled(mechanism)
+        except (AttributeError, TypeError) as exc:
+            raise RuntimeError(
+                "Aperture status attribute unsupported or missing: "
+                "ApertureMechanism.is_enabled."
+            ) from exc
+        if not enabled:
+            raise RuntimeError(
+                f"Aperture mechanism {mechanism!r} is disabled; "
+                f"refusing to {action}."
+            )
+
+    def _require_aperture_retractable(self, mechanism: str, action: str) -> None:
+        try:
+            retractable = self._aperture_adapter.is_retractable(mechanism)
+        except (AttributeError, TypeError) as exc:
+            raise RuntimeError(
+                "Aperture status attribute unsupported or missing: "
+                "ApertureMechanism.is_retractable."
+            ) from exc
+        if not retractable:
+            raise RuntimeError(
+                f"Aperture mechanism {mechanism!r} is not retractable; "
+                f"refusing to {action}."
+            )
+
+    def _assert_no_live_acquisition_for_aperture_mutation(self) -> None:
+        if getattr(self, "_acquisition_active", False):
+            raise RuntimeError(
+                "Aperture mutation is blocked because acquisition is active."
+            )
+
+    def _precheck_aperture_mutation(
+        self,
+        mechanism: str,
+        action: str,
+        *,
+        require_retractable: bool,
+    ) -> None:
+        self._assert_no_live_acquisition_for_aperture_mutation()
+        self._require_aperture_enabled(mechanism, action)
+        if require_retractable:
+            self._require_aperture_retractable(mechanism, action)
+
+
+    def _precheck_aperture_disable(self, mechanism: str) -> None:
+        try:
+            insertion_state = self._aperture_adapter.get_insertion_state(mechanism)
+        except (AttributeError, TypeError) as exc:
+            raise RuntimeError(
+                "Aperture insertion status unsupported or missing: "
+                "ApertureMechanism.insertion_state."
+            ) from exc
+        if insertion_state != "Retracted":
+            raise RuntimeError(
+                f"Aperture mechanism {mechanism!r} is not safe to disable while "
+                f"insertion_state is {insertion_state!r}; retract it first."
+            )
+
+
+    def _warn_aperture_metadata(self, message: str) -> None:
+        """Log metadata warnings without breaking lightweight unit instances."""
+        if not getattr(self, "_aperture_logging_ready", False):
+            return
+        try:
+            self.warn_stream(message)
+        except Exception:
+            pass
+
+    def _get_aperture_metadata(self) -> dict[str, Any]:
+        """Return a non-fatal snapshot of current aperture state."""
+        using_autoscript = bool(
+            getattr(self, "_aperture_autoscript_available", False)
+        )
+        metadata: dict[str, Any] = {
+            "source": "autoscript" if using_autoscript else "simulation",
+            "reason": (
+                None
+                if using_autoscript
+                else "AutoScript unavailable or testing mode; using simulated aperture state."
+            ),
+            "mechanisms": [],
+            "selected_apertures": {},
+            "insertion_states": {},
+            "errors": {},
+        }
+
+        adapter = getattr(self, "_aperture_adapter", None)
+        if adapter is None:
+            message = "Aperture adapter is not initialised."
+            metadata["source"] = "unavailable"
+            metadata["reason"] = message
+            metadata["errors"]["adapter"] = message
+            self._warn_aperture_metadata(message)
+            return metadata
+
+        try:
+            mechanisms = list(adapter.list_mechanisms())
+            metadata["mechanisms"] = mechanisms
+        except Exception as exc:
+            message = f"Could not list aperture mechanisms: {exc}"
+            metadata["errors"]["adapter"] = message
+            self._warn_aperture_metadata(message)
+            return metadata
+
+        for mechanism in mechanisms:
+            mechanism_errors: list[str] = []
+            selected = None
+            try:
+                apertures = adapter.list_apertures(mechanism)
+                selected = next(
+                    (aperture for aperture in apertures if aperture.selected),
+                    None,
+                )
+            except Exception as exc:
+                mechanism_errors.append(f"selected aperture: {exc}")
+
+            metadata["selected_apertures"][mechanism] = (
+                self._aperture_response_data(selected)
+            )
+
+            try:
+                metadata["insertion_states"][mechanism] = (
+                    adapter.get_insertion_state(mechanism)
+                )
+            except Exception as exc:
+                metadata["insertion_states"][mechanism] = None
+                mechanism_errors.append(f"insertion_state: {exc}")
+
+            if mechanism_errors:
+                message = "; ".join(mechanism_errors)
+                metadata["errors"][mechanism] = message
+                self._warn_aperture_metadata(
+                    f"Could not fully read aperture metadata for {mechanism!r}: {message}"
+                )
+
+        return metadata
+
+    @command(dtype_in=str, dtype_out=str)
+    def aperture_list(self, json_request: str = "{}") -> str:
+        """List available apertures without changing microscope state."""
+        action = "list"
+        mechanism = ""
+        try:
+            request = self._parse_aperture_request(
+                json_request,
+                require_mechanism=False,
+            )
+            mechanism = request.get("mechanism", "")
+            mechanism_names = (
+                [mechanism]
+                if mechanism
+                else self._aperture_adapter.list_mechanisms()
+            )
+            apertures = [
+                self._aperture_response_data(aperture)
+                | {"mechanism": aperture.mechanism, "selected": aperture.selected}
+                for mechanism_name in mechanism_names
+                for aperture in self._aperture_adapter.list_apertures(mechanism_name)
+            ]
+            insertion_state = (
+                self._aperture_adapter.get_insertion_state(mechanism)
+                if mechanism
+                else None
+            )
+            return self._aperture_response(
+                ok=True,
+                action=action,
+                mechanism=mechanism or "all",
+                insertion_state=insertion_state,
+                mechanisms=self._aperture_adapter.list_mechanisms(),
+                apertures=apertures,
+            )
+        except Exception as exc:
+            return self._aperture_error(action, mechanism, exc)
+
+    @command(dtype_in=str, dtype_out=str)
+    def aperture_get_selected(self, json_request: str) -> str:
+        """Return the selected aperture for one explicit mechanism."""
+        action = "get_selected"
+        mechanism = ""
+        try:
+            request = self._parse_aperture_request(json_request, require_mechanism=True)
+            mechanism = request["mechanism"]
+            aperture = self._aperture_adapter.get_selected_aperture(mechanism)
+            return self._aperture_response(
+                ok=True,
+                action=action,
+                mechanism=mechanism,
+                aperture=aperture,
+                insertion_state=self._aperture_adapter.get_insertion_state(mechanism),
+            )
+        except Exception as exc:
+            return self._aperture_error(action, mechanism, exc)
+
+    @command(dtype_in=str, dtype_out=str)
+    def aperture_is_enabled(self, json_request: str) -> str:
+        """Return whether one explicit aperture mechanism is enabled."""
+        action = "is_enabled"
+        mechanism = ""
+        try:
+            request = self._parse_aperture_request(json_request, require_mechanism=True)
+            mechanism = request["mechanism"]
+            return self._aperture_response(
+                ok=True,
+                action=action,
+                mechanism=mechanism,
+                enabled=self._aperture_adapter.is_enabled(mechanism),
+            )
+        except Exception as exc:
+            return self._aperture_error(action, mechanism, exc)
+
+    @command(dtype_in=str, dtype_out=str)
+    def aperture_is_retractable(self, json_request: str) -> str:
+        """Return whether one explicit aperture mechanism is retractable."""
+        action = "is_retractable"
+        mechanism = ""
+        try:
+            request = self._parse_aperture_request(json_request, require_mechanism=True)
+            mechanism = request["mechanism"]
+            return self._aperture_response(
+                ok=True,
+                action=action,
+                mechanism=mechanism,
+                retractable=self._aperture_adapter.is_retractable(mechanism),
+            )
+        except Exception as exc:
+            return self._aperture_error(action, mechanism, exc)
+
+    @command(dtype_in=str, dtype_out=str)
+    def aperture_enable(self, json_request: str) -> str:
+        """Enable one explicit aperture mechanism when AutoScript supports it."""
+        action = "enable"
+        mechanism = ""
+        try:
+            request = self._parse_aperture_request(json_request, require_mechanism=True)
+            mechanism = request["mechanism"]
+            self._assert_no_live_acquisition_for_aperture_mutation()
+            try:
+                enabled = self._aperture_adapter.enable(mechanism)
+            except (AttributeError, TypeError) as exc:
+                raise RuntimeError(
+                    "Unsupported AutoScript aperture operation 'enable': "
+                    "missing documented method ApertureMechanism.enable."
+                ) from exc
+            return self._aperture_response(
+                ok=True,
+                action=action,
+                mechanism=mechanism,
+                enabled=enabled,
+            )
+        except Exception as exc:
+            return self._aperture_error(action, mechanism, exc)
+
+    @command(dtype_in=str, dtype_out=str)
+    def aperture_disable(self, json_request: str) -> str:
+        """Disable one retracted aperture mechanism when AutoScript supports it."""
+        action = "disable"
+        mechanism = ""
+        try:
+            request = self._parse_aperture_request(json_request, require_mechanism=True)
+            mechanism = request["mechanism"]
+            self._assert_no_live_acquisition_for_aperture_mutation()
+            self._precheck_aperture_disable(mechanism)
+            try:
+                enabled = self._aperture_adapter.disable(mechanism)
+            except (AttributeError, TypeError) as exc:
+                raise RuntimeError(
+                    "Unsupported AutoScript aperture operation 'disable': "
+                    "missing documented method ApertureMechanism.disable."
+                ) from exc
+            return self._aperture_response(
+                ok=True,
+                action=action,
+                mechanism=mechanism,
+                enabled=enabled,
+            )
+        except Exception as exc:
+            return self._aperture_error(action, mechanism, exc)
+
+
+    @command(dtype_in=str, dtype_out=str)
+    def aperture_select(self, json_request: str) -> str:
+        """Select an aperture only after an explicit JSON command."""
+        action = "select"
+        mechanism = ""
+        try:
+            request = self._parse_aperture_request(
+                json_request,
+                require_mechanism=True,
+                require_name=False,
+            )
+            mechanism = request["mechanism"]
+            name = request.get("name")
+            if not isinstance(name, str) or not name:
+                raise ValueError("Aperture request requires a non-empty string 'name'.")
+            self.info_stream(
+                f"Aperture change requested: action={action}, mechanism={mechanism!r}, name={name!r}"
+            )
+            self._precheck_aperture_mutation(
+                mechanism,
+                "select aperture",
+                require_retractable=False,
+            )
+            aperture = self._aperture_adapter.select_aperture(mechanism, name)
+            return self._aperture_response(
+                ok=True,
+                action=action,
+                mechanism=mechanism,
+                aperture=aperture,
+                insertion_state=self._aperture_adapter.get_insertion_state(mechanism),
+            )
+        except Exception as exc:
+            return self._aperture_error(action, mechanism, exc)
+
+    @command(dtype_in=str, dtype_out=str)
+    def aperture_insert(self, json_request: str) -> str:
+        """Insert one mechanism only after an explicit JSON command."""
+        action = "insert"
+        mechanism = ""
+        try:
+            request = self._parse_aperture_request(json_request, require_mechanism=True)
+            mechanism = request["mechanism"]
+            self.info_stream(
+                f"Aperture change requested: action={action}, mechanism={mechanism!r}"
+            )
+            self._precheck_aperture_mutation(
+                mechanism,
+                "insert aperture mechanism",
+                require_retractable=True,
+            )
+            insertion_state = self._aperture_adapter.insert_mechanism(mechanism)
+            aperture = self._aperture_adapter.get_selected_aperture(mechanism)
+            return self._aperture_response(
+                ok=True,
+                action=action,
+                mechanism=mechanism,
+                aperture=aperture,
+                insertion_state=insertion_state,
+            )
+        except Exception as exc:
+            return self._aperture_error(action, mechanism, exc)
+
+    @command(dtype_in=str, dtype_out=str)
+    def aperture_retract(self, json_request: str) -> str:
+        """Retract one mechanism only after an explicit JSON command."""
+        action = "retract"
+        mechanism = ""
+        try:
+            request = self._parse_aperture_request(json_request, require_mechanism=True)
+            mechanism = request["mechanism"]
+            self.info_stream(
+                f"Aperture change requested: action={action}, mechanism={mechanism!r}"
+            )
+            self._precheck_aperture_mutation(
+                mechanism,
+                "retract aperture mechanism",
+                require_retractable=True,
+            )
+            insertion_state = self._aperture_adapter.retract_mechanism(mechanism)
+            return self._aperture_response(
+                ok=True,
+                action=action,
+                mechanism=mechanism,
+                insertion_state=insertion_state,
+            )
+        except Exception as exc:
+            return self._aperture_error(action, mechanism, exc)
+
 
     # ------------------------------------------------------------------
     # Internal acquisition helpers
@@ -266,7 +732,15 @@ class AutoScriptMicroscope(ElectronMicroscope):
         if not isinstance(adorned, list):
             adorned = [adorned]
         data_server = self._detector_proxies.get("data")
-        return save_acquisition(self, data_server, "stem_image", detector_list, adorned, output_format=output_format)
+        return save_acquisition(
+            self,
+            data_server,
+            "stem_image",
+            detector_list,
+            adorned,
+            file_attrs={"apertures": self._get_aperture_metadata()},
+            output_format=output_format,
+        )
 
 
     def _acquire_camera_image(self, imsize: int, exposure_time: float, detector: str, readout_area: str) -> str:
@@ -277,7 +751,14 @@ class AutoScriptMicroscope(ElectronMicroscope):
         settings = CameraAcquisitionSettings(camera_detector=detector, size=imsize, exposure_time=exposure_time, fixed_readout_area=readout_area, frame_combining=1)
         adorned = self._microscope.acquisition.acquire_camera_image_advanced(settings)
         data_server = self._detector_proxies.get("data")
-        return save_acquisition(self, data_server, "camera_image", str(detector), adorned)
+        return save_acquisition(
+            self,
+            data_server,
+            "camera_image",
+            str(detector),
+            adorned,
+            file_attrs={"apertures": self._get_aperture_metadata()},
+        )
 
     def _acquire_scanned_data_advanced(self, imsize: int, dwell_time: float, detector: str, scan_region: list[float]) -> str:
         """
@@ -291,7 +772,15 @@ class AutoScriptMicroscope(ElectronMicroscope):
         settings = StemDataSettings(dwell_time=dwell_time, detector_types=[camera_detector], size=imsize, region=Region(RegionCoordinateSystem.RELATIVE, Rectangle(*scan_region)))
         adorned = self._microscope.acquisition.acquire_stem_data_advanced(settings)
         data_server = self._detector_proxies.get("data")
-        return save_acquisition(self, data_server, "stem_data", str(detector), adorned, dataset_name="stem_data")
+        return save_acquisition(
+            self,
+            data_server,
+            "stem_data",
+            str(detector),
+            adorned,
+            dataset_name="stem_data",
+            file_attrs={"apertures": self._get_aperture_metadata()},
+        )
 
     # test: not sure this is how we want to save
     def _acquire_spectrum(self, detector_name: str, exposure_time: float) -> str:
@@ -303,7 +792,15 @@ class AutoScriptMicroscope(ElectronMicroscope):
         settings.exposure_time_type = ExposureTimeType.LIVE_TIME
         spectrum = self._microscope.analysis.eds.acquire_spectrum(settings)
         data_server = self._detector_proxies.get("data")
-        return save_acquisition(self, data_server, "spectrum", detector_name, spectrum, dataset_name="spectrum")
+        return save_acquisition(
+            self,
+            data_server,
+            "spectrum",
+            detector_name,
+            spectrum,
+            dataset_name="spectrum",
+            file_attrs={"apertures": self._get_aperture_metadata()},
+        )
 
     def _place_beam(self, position) -> None:
         """

--- a/asyncroscopy/instruments/electron_microscope/electron_microscope.py
+++ b/asyncroscopy/instruments/electron_microscope/electron_microscope.py
@@ -83,6 +83,7 @@ class ElectronMicroscope(Instrument):
         self._microscope: Optional[object] = None
         self._stem_mode: bool = False
         self._detector_proxies: dict[str, tango.DeviceProxy] = {}
+        self._acquisition_active: bool = False
 
     def read_instrument_type(self) -> str:
         return 'TEM'
@@ -106,6 +107,14 @@ class ElectronMicroscope(Instrument):
     def read_stem_mode(self) -> bool:
         return self._stem_mode
 
+    def _run_acquisition_command(self, acquire, *args, **kwargs):
+        previous_active = getattr(self, "_acquisition_active", False)
+        self._acquisition_active = True
+        try:
+            return acquire(*args, **kwargs)
+        finally:
+            self._acquisition_active = previous_active
+
     @command
     def Disconnect(self) -> None:
         """Disconnect from microscope hardware gracefully."""
@@ -117,31 +126,31 @@ class ElectronMicroscope(Instrument):
         """Acquire a single spectrum and return its DATA/Tiled unique id."""
         detector_name = detector_name.lower().strip()
         proxy = self._detector_proxies.get(detector_name)
-        return self._acquire_spectrum(detector_name, proxy.exposure_time)
+        return self._run_acquisition_command(self._acquire_spectrum, detector_name, proxy.exposure_time)
 
     @command(dtype_in=DevVarStringArray, dtype_out=str)
     def acquire_scanned_image(self, detector_list: list[str] = ['haadf']) -> str:
         """Acquire an image with scanning detectors and return its DATA/Tiled key."""
         scan = self._detector_proxies.get('scan')
-        return self._acquire_scanned_image(scan.imsize, scan.dwell_time, detector_list, list(scan.scan_region), scan.output_format)
+        return self._run_acquisition_command(self._acquire_scanned_image, scan.imsize, scan.dwell_time, detector_list, list(scan.scan_region), scan.output_format)
 
     @command(dtype_out=str)
     def acquire_scanned_data_advanced(self) -> str:
         """Trigger an advanced 4D scanned data acquisition with the Ceta camera."""
         scan = self._detector_proxies.get('scan')
-        return self._acquire_scanned_data_advanced(scan.imsize, scan.dwell_time, 'BM-Ceta', list(scan.scan_region))
+        return self._run_acquisition_command(self._acquire_scanned_data_advanced, scan.imsize, scan.dwell_time, 'BM-Ceta', list(scan.scan_region))
 
     @command(dtype_out=str)
     def acquire_camera_image(self) -> str:
         """Acquire a camera image using settings from the camera device."""
         camera = self._detector_proxies.get('camera')
-        return self._acquire_camera_image(camera.imsize, camera.exposure_time, 'BM-Ceta', camera.readout_area)
+        return self._run_acquisition_command(self._acquire_camera_image, camera.imsize, camera.exposure_time, 'BM-Ceta', camera.readout_area)
 
     @command(dtype_out=str)
     def acquire_flucam_image(self) -> str:
         """Acquire a Flucam image using settings from the flucam device."""
         flucam = self._detector_proxies.get('flucam')
-        return self._acquire_camera_image(flucam.imsize, flucam.exposure_time, 'Flucam', flucam.readout_area)
+        return self._run_acquisition_command(self._acquire_camera_image, flucam.imsize, flucam.exposure_time, 'Flucam', flucam.readout_area)
 
     @command(dtype_in=int, dtype_out=DevEncoded)
     def get_image_data_cached(self, index: int) -> tuple[str, bytes]:

--- a/asyncroscopy/instruments/electron_microscope/hardware/aperture.py
+++ b/asyncroscopy/instruments/electron_microscope/hardware/aperture.py
@@ -1,0 +1,393 @@
+"""Simulation-first aperture control device.
+
+This module deliberately has no AutoScript imports and performs no microscope
+I/O.  The public Tango interface is intended to remain stable when a hardware
+backend is added later.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import asdict, dataclass
+
+from tango import AttrWriteType, DevState
+from tango.server import Device, attribute, command
+
+
+@dataclass(frozen=True)
+class ApertureInfo:
+    """Vendor-neutral description of one aperture."""
+
+    mechanism: str
+    name: str
+    aperture_type: str
+    diameter_m: float | None
+    inserted: bool | None
+    selected: bool
+
+
+@dataclass
+class _SimulatedMechanism:
+    apertures: tuple[tuple[str, str, float | None], ...]
+    inserted: bool
+    selected_name: str | None
+    last_selected_name: str
+    enabled: bool
+    retractable: bool
+
+
+class SimulatedApertureBackend:
+    """Deterministic in-memory aperture state for a representative Spectra STEM."""
+
+    def __init__(self) -> None:
+        self._mechanisms: dict[str, _SimulatedMechanism] = {
+            "condenser": self._mechanism((30, 50, 70, 100), "50 um", inserted=True),
+            "objective": self._mechanism((20, 40, 70, 100), "40 um", inserted=False),
+            "selected_area": self._mechanism((10, 20, 40, 100), "40 um", inserted=False),
+            "projector": self._mechanism((50, 100, 200), "100 um", inserted=False),
+        }
+
+    @staticmethod
+    def _mechanism(
+        diameters_um: tuple[int, ...],
+        default_name: str,
+        *,
+        inserted: bool,
+    ) -> _SimulatedMechanism:
+        apertures = tuple(
+            (f"{diameter} um", "Circular", diameter * 1e-6)
+            for diameter in diameters_um
+        )
+        return _SimulatedMechanism(
+            apertures=apertures,
+            inserted=inserted,
+            selected_name=default_name if inserted else None,
+            last_selected_name=default_name,
+            enabled=True,
+            retractable=True,
+        )
+
+    @property
+    def mechanism_names(self) -> tuple[str, ...]:
+        return tuple(self._mechanisms)
+
+    def list_mechanisms(self) -> list[str]:
+        """Return simulated mechanism names using the adapter interface."""
+        return list(self.mechanism_names)
+
+    def _get(self, mechanism: str) -> _SimulatedMechanism:
+        try:
+            return self._mechanisms[mechanism]
+        except KeyError as exc:
+            available = ", ".join(self.mechanism_names)
+            raise ValueError(
+                f"Unknown aperture mechanism {mechanism!r}. Available mechanisms: {available}."
+            ) from exc
+
+    def list_apertures(self, mechanism: str) -> list[ApertureInfo]:
+        state = self._get(mechanism)
+        return [
+            ApertureInfo(
+                mechanism=mechanism,
+                name=name,
+                aperture_type=aperture_type,
+                diameter_m=diameter_m,
+                inserted=state.inserted,
+                selected=name == state.selected_name,
+            )
+            for name, aperture_type, diameter_m in state.apertures
+        ]
+
+    def selected_aperture(self, mechanism: str) -> ApertureInfo | None:
+        return next(
+            (item for item in self.list_apertures(mechanism) if item.selected),
+            None,
+        )
+
+    def get_selected_aperture(self, mechanism: str) -> ApertureInfo:
+        """Return the selected aperture using the adapter interface."""
+        selected = self.selected_aperture(mechanism)
+        if selected is None:
+            raise RuntimeError(f"No aperture is selected for mechanism {mechanism!r}.")
+        return selected
+
+    def is_inserted(self, mechanism: str) -> bool:
+        return self._get(mechanism).inserted
+
+    def get_insertion_state(self, mechanism: str) -> str:
+        return "Inserted" if self.is_inserted(mechanism) else "Retracted"
+
+    def is_enabled(self, mechanism: str) -> bool:
+        return self._get(mechanism).enabled
+
+    def is_retractable(self, mechanism: str) -> bool:
+        return self._get(mechanism).retractable
+
+    def enable(self, mechanism: str) -> bool:
+        state = self._get(mechanism)
+        state.enabled = True
+        return state.enabled
+
+    def disable(self, mechanism: str) -> bool:
+        state = self._get(mechanism)
+        state.enabled = False
+        return state.enabled
+
+    def select_aperture(self, mechanism: str, name: str) -> ApertureInfo:
+        state = self._get(mechanism)
+        available_names = [item[0] for item in state.apertures]
+        if name not in available_names:
+            available = ", ".join(available_names)
+            raise ValueError(
+                f"Unknown aperture {name!r} for mechanism {mechanism!r}. "
+                f"Available apertures: {available}."
+            )
+
+        # AutoScript selection semantics insert the containing mechanism.
+        state.inserted = True
+        state.selected_name = name
+        state.last_selected_name = name
+        selected = self.selected_aperture(mechanism)
+        assert selected is not None
+        return selected
+
+    def insert_mechanism(self, mechanism: str) -> str:
+        state = self._get(mechanism)
+        state.inserted = True
+        state.selected_name = state.last_selected_name
+        selected = self.selected_aperture(mechanism)
+        assert selected is not None
+        return "Inserted"
+
+    def retract_mechanism(self, mechanism: str) -> str:
+        state = self._get(mechanism)
+        if state.selected_name is not None:
+            state.last_selected_name = state.selected_name
+        state.inserted = False
+        state.selected_name = None
+        return "Retracted"
+
+
+class APERTURE(Device):
+    """PyTango aperture device backed only by deterministic simulation state."""
+
+    mechanism_names = attribute(
+        label="Aperture Mechanisms",
+        dtype=(str,),
+        max_dim_x=16,
+        access=AttrWriteType.READ,
+        doc="Names of simulated aperture mechanisms.",
+    )
+
+    selected_aperture_name = attribute(
+        label="Selected Aperture Name",
+        dtype=str,
+        access=AttrWriteType.READ,
+        doc="Selected aperture on the mechanism used by the latest successful command.",
+    )
+
+    selected_aperture_type = attribute(
+        label="Selected Aperture Type",
+        dtype=str,
+        access=AttrWriteType.READ,
+        doc="Type of the selected aperture on the active mechanism.",
+    )
+
+    selected_aperture_diameter_m = attribute(
+        label="Selected Aperture Diameter",
+        dtype=float,
+        unit="m",
+        access=AttrWriteType.READ,
+        doc="Selected circular-aperture diameter in meters, or NaN when unavailable.",
+    )
+
+    insertion_state = attribute(
+        label="Insertion State",
+        dtype=str,
+        access=AttrWriteType.READ,
+        doc="Inserted or Retracted state of the active simulated mechanism.",
+    )
+
+    last_error = attribute(
+        label="Last Error",
+        dtype=str,
+        access=AttrWriteType.READ,
+        doc="Most recent command validation error, cleared after a successful command.",
+    )
+
+    def init_device(self) -> None:
+        Device.init_device(self)
+        self._backend = SimulatedApertureBackend()
+        self._active_mechanism = self._backend.mechanism_names[0]
+        self._last_error = ""
+        self.set_state(DevState.ON)
+        self.info_stream("APERTURE simulation device initialised")
+
+    @staticmethod
+    def _json(payload: dict) -> str:
+        return json.dumps(payload, sort_keys=True, separators=(",", ":"), allow_nan=False)
+
+    @staticmethod
+    def _aperture_payload(aperture: ApertureInfo | None) -> dict | None:
+        return asdict(aperture) if aperture is not None else None
+
+    def _response(
+        self,
+        *,
+        status: str,
+        mechanism: str,
+        selected_aperture: ApertureInfo | None,
+        inserted: bool | None,
+        error: str | None,
+        **extra,
+    ) -> str:
+        payload = {
+            "status": status,
+            "mechanism": mechanism,
+            "selected_aperture": self._aperture_payload(selected_aperture),
+            "inserted": inserted,
+            "error": error,
+        }
+        payload.update(extra)
+        return self._json(payload)
+
+    def _success(self, mechanism: str) -> str:
+        self._active_mechanism = mechanism
+        self._last_error = ""
+        return self._response(
+            status="ok",
+            mechanism=mechanism,
+            selected_aperture=self._backend.selected_aperture(mechanism),
+            inserted=self._backend.is_inserted(mechanism),
+            error=None,
+        )
+
+    def _failure(self, mechanism: str, exc: ValueError) -> str:
+        self._last_error = str(exc)
+        return self._response(
+            status="error",
+            mechanism=mechanism,
+            selected_aperture=None,
+            inserted=None,
+            error=self._last_error,
+        )
+
+    def read_mechanism_names(self) -> list[str]:
+        return list(self._backend.mechanism_names)
+
+    def read_selected_aperture_name(self) -> str:
+        selected = self._backend.selected_aperture(self._active_mechanism)
+        return selected.name if selected is not None else ""
+
+    def read_selected_aperture_type(self) -> str:
+        selected = self._backend.selected_aperture(self._active_mechanism)
+        return selected.aperture_type if selected is not None else ""
+
+    def read_selected_aperture_diameter_m(self) -> float:
+        selected = self._backend.selected_aperture(self._active_mechanism)
+        if selected is None or selected.diameter_m is None:
+            return math.nan
+        return selected.diameter_m
+
+    def read_insertion_state(self) -> str:
+        return "Inserted" if self._backend.is_inserted(self._active_mechanism) else "Retracted"
+
+    def read_last_error(self) -> str:
+        return self._last_error
+
+    @command(dtype_out=str)
+    def list_apertures(self) -> str:
+        """Return all simulated mechanisms and apertures as deterministic JSON."""
+        self._last_error = ""
+        apertures = [
+            asdict(aperture)
+            for mechanism in self._backend.mechanism_names
+            for aperture in self._backend.list_apertures(mechanism)
+        ]
+        return self._response(
+            status="ok",
+            mechanism="all",
+            selected_aperture=None,
+            inserted=None,
+            error=None,
+            apertures=apertures,
+        )
+
+    @command(dtype_in=str, dtype_out=str)
+    def get_selected_aperture(self, mechanism: str) -> str:
+        """Return the selected aperture for one simulated mechanism."""
+        try:
+            self._backend.is_inserted(mechanism)
+            return self._success(mechanism)
+        except ValueError as exc:
+            return self._failure(mechanism, exc)
+
+    @command(dtype_in=str, dtype_out=str)
+    def select_aperture(self, json_request: str) -> str:
+        """Select by JSON request: ``{"mechanism": "...", "name": "..."}``."""
+        mechanism = ""
+        try:
+            try:
+                request = json.loads(json_request)
+            except (json.JSONDecodeError, TypeError) as exc:
+                raise ValueError("Invalid JSON request.") from exc
+            if not isinstance(request, dict):
+                raise ValueError("Aperture selection request must be a JSON object.")
+            requested_mechanism = request.get("mechanism")
+            name = request.get("name")
+            if not isinstance(requested_mechanism, str) or not requested_mechanism:
+                raise ValueError("Selection request requires a non-empty string 'mechanism'.")
+            if not isinstance(name, str) or not name:
+                raise ValueError("Selection request requires a non-empty string 'name'.")
+            mechanism = requested_mechanism
+            self._backend.select_aperture(mechanism, name)
+            return self._success(mechanism)
+        except ValueError as exc:
+            return self._failure(mechanism, exc)
+
+    @command(dtype_in=str, dtype_out=str)
+    def insert_mechanism(self, mechanism: str) -> str:
+        """Insert one simulated mechanism."""
+        try:
+            self._backend.insert_mechanism(mechanism)
+            return self._success(mechanism)
+        except ValueError as exc:
+            return self._failure(mechanism, exc)
+
+    @command(dtype_in=str, dtype_out=str)
+    def retract_mechanism(self, mechanism: str) -> str:
+        """Retract one simulated mechanism."""
+        try:
+            self._backend.retract_mechanism(mechanism)
+            return self._success(mechanism)
+        except ValueError as exc:
+            return self._failure(mechanism, exc)
+
+    @command(dtype_out=str)
+    def refresh(self) -> str:
+        """Return a deterministic snapshot of all current simulation state."""
+        self._last_error = ""
+        mechanisms = []
+        for mechanism in self._backend.mechanism_names:
+            mechanisms.append(
+                {
+                    "mechanism": mechanism,
+                    "selected_aperture": self._aperture_payload(
+                        self._backend.selected_aperture(mechanism)
+                    ),
+                    "inserted": self._backend.is_inserted(mechanism),
+                }
+            )
+        return self._response(
+            status="ok",
+            mechanism="all",
+            selected_aperture=None,
+            inserted=None,
+            error=None,
+            mechanisms=mechanisms,
+        )
+
+
+if __name__ == "__main__":
+    APERTURE.run_server()

--- a/docs/apertures_autoscript_api_map.md
+++ b/docs/apertures_autoscript_api_map.md
@@ -1,0 +1,180 @@
+# AutoScript aperture API map
+
+This note records the aperture-control API exposed by the provided Thermo Fisher AutoScript TEM HTML reference. It intentionally uses the documented names and paths without introducing wrapper method names.
+
+## Imports and client object
+
+The AutoScript client startup documentation imports and creates the microscope client as follows:
+
+```python
+from autoscript_tem_microscope_client import TemMicroscopeClient
+
+microscope = TemMicroscopeClient()
+```
+
+The client must be connected using the normal AutoScript connection procedure before accessing microscope objects.
+
+No aperture-specific import is required when selecting an aperture already returned by AutoScript. The position property accepts a `Point`, list, or tuple, so a two-value list or tuple can be used without importing `Point`.
+
+## Motorized aperture collection
+
+The exact collection path is:
+
+```python
+microscope.optics.aperture_mechanisms
+```
+
+Available motorized mechanisms are discovered at runtime:
+
+```python
+mechanism_names = microscope.optics.aperture_mechanisms.get_available()
+```
+
+`get_available()` returns `list[str]` identifiers. A mechanism is retrieved by identifier with:
+
+```python
+mechanism = microscope.optics.aperture_mechanisms.get_mechanism(mechanism_type)
+```
+
+Only motorized mechanisms are supported by `get_mechanism()`. An unsupported identifier raises an exception.
+
+## Documented mechanism names
+
+`ApertureMechanismType` documents these exact identifiers:
+
+| Enumeration item | String value | Meaning |
+|---|---|---|
+| `C1` | `"C1"` | C1 condenser-lens aperture mechanism |
+| `C2` | `"C2"` | C2 condenser-lens aperture mechanism |
+| `C3` | `"C3"` | C3 condenser-lens aperture mechanism |
+| `OBJECTIVE` | `"Objective"` | Objective-lens aperture mechanism |
+| `SA` | `"SA"` | Selected-area aperture mechanism |
+| `TRANSFER_LENS` | `"TransferLens"` | Transfer-lens aperture mechanism |
+
+The collection also provides these documented convenience properties:
+
+```python
+microscope.optics.aperture_mechanisms.C1
+microscope.optics.aperture_mechanisms.C2
+microscope.optics.aperture_mechanisms.C3       # if present
+microscope.optics.aperture_mechanisms.objective
+microscope.optics.aperture_mechanisms.SA
+```
+
+The reference does not document a projector-aperture mechanism or a generic `microscope.optics.apertures` path. Code should use `get_available()` because the mechanisms physically installed on a microscope can differ.
+
+## Aperture mechanism API
+
+Given an `ApertureMechanism` object named `mechanism`, the exact documented interface is:
+
+| Operation | AutoScript API | Type |
+|---|---|---|
+| List available apertures | `mechanism.apertures` | Read-only `list[Aperture]` |
+| Get selected aperture | `mechanism.aperture` | `Aperture | None` |
+| Select an aperture | `mechanism.aperture = aperture` | Assign an `Aperture` object |
+| Read insertion state | `mechanism.insertion_state` | Read-only `str` |
+| Read enabled state | `mechanism.is_enabled` | Read-only `bool` |
+| Read retractability | `mechanism.is_retractable` | Read-only `bool` |
+| Enable | `mechanism.enable()` | Method |
+| Disable | `mechanism.disable()` | Method |
+| Insert | `mechanism.insert()` | Method |
+| Retract | `mechanism.retract()` | Method |
+| Read position | `mechanism.position` | `Point | None` |
+| Set position | `mechanism.position = (x, y)` | `Point`, list, or tuple; meters |
+| Reset aligned positions | `mechanism.reset_positions()` | Method |
+
+### Listing and selecting apertures
+
+Each item returned by `mechanism.apertures` is an `Aperture` with exactly these fields:
+
+```python
+aperture.name       # str
+aperture.type       # str, using an ApertureType value
+aperture.diameter   # float in meters for circular apertures; otherwise None
+```
+
+The documented selection pattern is to obtain an existing object from `mechanism.apertures` and assign it to `mechanism.aperture`:
+
+```python
+available = mechanism.apertures
+wanted_name = "<name reported by AutoScript>"
+selected = next(item for item in available if item.name == wanted_name)
+mechanism.aperture = selected
+```
+
+AutoScript documents `Aperture.name` as the unique identifier. When an aperture is selected, only its `name` is used for identification. An unmatched name causes selection to fail.
+
+Setting `mechanism.aperture` inserts its mechanism if it is currently retracted. Reading `mechanism.aperture` returns `None` when no aperture is selected, including after retraction.
+
+### Insertion state
+
+`mechanism.insertion_state` maps to `ApertureMechanismInsertionState` and returns one of these exact strings:
+
+```text
+"Retracted"
+"Inserted"
+"Moving"
+"Arbitrary"
+"Error"
+```
+
+The mechanism must be enabled before reading `insertion_state`. Insertion and retraction require the mechanism to be enabled and retractable.
+
+### Position and centering
+
+`mechanism.position` gets or sets the XY position of the selected aperture in meters:
+
+```python
+position = mechanism.position
+x = position.x
+y = position.y
+
+mechanism.position = (x, y)
+```
+
+The mechanism must be enabled and inserted before its position can be read or changed. A returned value of `None` means no aperture is selected.
+
+The position is stored as a preset for the currently selected aperture. Selecting that aperture again recovers its stored position. `mechanism.reset_positions()` restores the default microscope-alignment positions for every aperture on that mechanism; it cannot reset only one aperture.
+
+## Asyncroscopy read-only status commands
+
+The current `AutoScriptMicroscope` Tango aperture path exposes read-only status commands for normal motorized aperture mechanisms:
+
+```python
+microscope.aperture_is_enabled(json.dumps({"mechanism": "C2"}))
+microscope.aperture_is_retractable(json.dumps({"mechanism": "C2"}))
+```
+
+These commands read `ApertureMechanism.is_enabled` and `ApertureMechanism.is_retractable` through `microscope.optics.aperture_mechanisms`. Separate explicit mutation commands expose `ApertureMechanism.enable()` and `ApertureMechanism.disable()` when those methods are present. No status or mutation command calls position setters, centering/reset operations, or any energy-filter aperture API.
+
+## Energy-filter aperture API
+
+Energy-filter apertures use a separate documented path:
+
+```python
+microscope.optics.energy_filter.apertures
+```
+
+Its exact properties are:
+
+```python
+microscope.optics.energy_filter.apertures.available_values  # read-only list[str]
+microscope.optics.energy_filter.apertures.value             # get/set str
+```
+
+Only a value returned by `available_values` may be assigned to `value`. This interface is distinct from the motorized `ApertureMechanism` API.
+
+## Version notes
+
+The provided reference was generated for AutoScript TEM 1.15.0.484. Its aperture structure exposes `name`, `type`, and `diameter`. Implementations targeting this newer structure-based API should prefer `name` for selection, because the documentation identifies `name` as unique and states that only the name is used during selection.
+
+Availability must still be detected at runtime with `get_available()` and `mechanism.apertures`; mechanism inventory and aperture names must not be hard-coded from one Spectra configuration.
+
+## Spectra safety rules
+
+- Read-only discovery and status operations are safe: `get_available()`, `get_mechanism()`, `apertures`, `aperture`, `is_enabled`, `is_retractable`, and—when enabled—`insertion_state` and `position`.
+- Aperture selection, insertion, retraction, enabling, disabling, position changes, and position resets must occur only through explicit user commands. Current mutation commands also perform status prechecks and reject while a microscope acquisition command is active before calling AutoScript.
+- Image acquisition must not automatically select, insert, retract, center, enable, disable, or reset an aperture unless that behavior is requested and designed separately later.
+- Before selection, check `is_enabled`. Before insertion or retraction, check both `is_enabled` and `is_retractable`. Before disabling, require an explicit `Retracted` insertion state. Report disabled, non-retractable, unsafe-to-disable, or unsupported/missing status clearly instead of guessing.
+- Before reading or changing position, confirm that the mechanism is enabled, inserted, and has a selected aperture.
+- Treat `"Moving"`, `"Arbitrary"`, and `"Error"` as non-ready states; do not issue an automatic follow-up movement.

--- a/docs/spectra_aperture_automation.md
+++ b/docs/spectra_aperture_automation.md
@@ -1,0 +1,231 @@
+# Spectra aperture automation
+
+## What aperture automation means
+
+In a Spectra TEM/STEM, an aperture is a physical element in the electron column. Selecting, inserting, retracting, or centering one changes which electrons continue through the microscope. Depending on the aperture and operating mode, this can change beam current, convergence angle, diffraction contrast, the selected specimen area, detector count rate, and image or spectrum quality.
+
+In asyncroscopy, aperture automation means exposing those operations as explicit, inspectable Tango commands. A client can first ask what mechanisms and aperture names are available, read the current state, and then—after the microscopist confirms the microscope condition—request a specific change.
+
+Automation does not mean that asyncroscopy should decide which physical aperture is scientifically appropriate. That remains an experimental decision made by the microscopist.
+
+## Physical aperture roles
+
+### Condenser apertures
+
+Condenser apertures are part of the illumination system. They affect the beam current and illumination or probe-forming conditions. In STEM, changing a condenser aperture can alter probe current and convergence conditions, which in turn affects spatial resolution, depth of field, detector signal, and dose.
+
+The provided AutoScript reference identifies motorized condenser mechanisms as `C1`, `C2`, and `C3`; `C3` is present only on configurations that provide it. The asyncroscopy simulator uses the broader name `condenser`, but real hardware commands must use a mechanism name returned by the microscope.
+
+### Objective aperture
+
+The objective aperture is used primarily in TEM imaging and diffraction-contrast workflows. It limits which scattered beams contribute to the image and can be used for bright-field or dark-field selection. Inserting the wrong objective aperture can strongly change contrast or exclude information needed by the experiment.
+
+The provided AutoScript reference documents the motorized mechanism identifier `Objective`. Availability still depends on the installed microscope configuration.
+
+### Selected-area aperture
+
+The selected-area aperture defines the specimen region contributing to a selected-area diffraction pattern. Its physical size and the microscope imaging conditions determine the effective selected region at the specimen.
+
+The provided AutoScript reference documents this mechanism as `SA`. It should not be inserted blindly: the microscopist should first establish the intended image/diffraction condition and confirm that no acquisition is running.
+
+### Projector aperture
+
+The supplied AutoScript aperture-mechanism documentation does **not** identify a mechanism named `Projector`. It does list `TransferLens`, but that must not be assumed to be equivalent to a projector aperture without confirmation for the specific instrument.
+
+`projector` currently exists only as a simulation-first asyncroscopy category. Do not send that name to a real Spectra unless runtime discovery reports it. Real hardware support must always be determined from `aperture_list("{}")` and the AutoScript `get_available()` result.
+
+## Supported automation operations
+
+### Read-only inspection
+
+The current asyncroscopy interface can:
+
+- list mechanisms reported by the active backend;
+- list the aperture names, types, and diameters associated with a mechanism;
+- identify the selected aperture;
+- report insertion state;
+- report whether a mechanism is enabled with `aperture_is_enabled()`;
+- report whether a mechanism is retractable with `aperture_is_retractable()`;
+- indicate whether the response came from AutoScript or the simulator.
+
+These status commands are read-only. They do not enable, disable, insert, retract, select, move, or center an aperture. Read-only inspection should always be performed before requesting a change.
+
+### Aperture selection
+
+An aperture is selected by its exact reported name. Diameter is metadata, not the selection key. This matters because non-circular apertures can have no diameter, and two apertures should not be treated as interchangeable merely because their nominal diameters match.
+
+On real hardware, available names and mechanisms are discovered dynamically. Simulation names such as `"50 um"` are examples and must not be copied into a real experiment without verifying the live inventory.
+
+`aperture_select()` now performs a read-only enabled-state precheck before assigning the selected aperture. If the mechanism reports disabled, or if the enabled-state status cannot be read, asyncroscopy rejects the request before calling AutoScript selection.
+
+### Insertion and retraction
+
+Insertion and retraction are separate, explicit commands. Whether a mechanism is retractable and whether the operation is allowed depend on the physical mechanism and its current AutoScript state.
+
+`aperture_insert()` and `aperture_retract()` now perform read-only `is_enabled` and `is_retractable` prechecks before calling AutoScript mutation methods. If either status is false, unsupported, or missing, asyncroscopy rejects the request without inserting or retracting the mechanism.
+
+The command response should be checked after every request. A software response is not a substitute for confirming the microscope state in the instrument UI when establishing a new workflow.
+
+### Enable and disable
+
+`aperture_enable()` and `aperture_disable()` expose AutoScript `ApertureMechanism.enable()` and `ApertureMechanism.disable()` for normal motorized aperture mechanisms only. If the mechanism does not provide the documented method, asyncroscopy reports the operation as unsupported rather than guessing.
+
+`aperture_enable()` is allowed even when `aperture_is_enabled()` reports `false`, because enabling is the operation that recovers that state. `aperture_disable()` is conservative: it only runs when the mechanism insertion state is explicitly `"Retracted"`. If the mechanism is inserted, moving, arbitrary, in error, or its insertion state cannot be read, asyncroscopy rejects the disable request before calling AutoScript.
+### Centering and position
+
+The supplied AutoScript API documents `ApertureMechanism.position` as an XY position in meters. It can be read or set only when the mechanism is enabled, inserted, and has a selected aperture. AutoScript also documents `reset_positions()` for restoring aligned positions for all apertures on a mechanism.
+
+The isolated asyncroscopy AutoScript adapter supports the documented position property, but the current safe Tango command set does not expose a public centering command. Centering should remain unavailable to routine clients until limits, confirmation behavior, logging, and hardware tests are defined for the specific Spectra.
+
+## Operations that must not happen automatically
+
+Asyncroscopy should not automatically:
+
+- change an aperture while an image, diffraction pattern, EDS spectrum, or EELS spectrum is being acquired;
+- select an aperture from diameter alone when AutoScript provides a unique name;
+- insert an objective or selected-area aperture without explicit user confirmation;
+- move or recenter an aperture as a side effect of image acquisition;
+- assume that the simulator's mechanism names exist on the real microscope;
+- treat `Moving`, `Arbitrary`, or `Error` as ready states.
+
+Acquisition methods do not call the aperture-changing commands. Selection, insertion, retraction, enable, and disable are manual automation actions, and the current `AutoScriptMicroscope` command path rejects those aperture mutations while a microscope acquisition command is active. Read-only aperture commands and metadata reads remain allowed during acquisition.
+
+## JSON command examples
+
+The examples below show requests passed to the `AutoScriptMicroscope` Tango device. Responses are JSON strings and should be decoded and checked before continuing.
+
+### List all mechanisms and apertures
+
+Request:
+
+```json
+{}
+```
+
+Python client:
+
+```python
+import json
+import tango
+
+microscope = tango.DeviceProxy("asyncroscopy/autoscriptmicroscope/default")
+response = json.loads(microscope.aperture_list("{}"))
+print(json.dumps(response, indent=2))
+```
+
+The response includes `mechanisms`, `apertures`, and `autoscript_available`. If `autoscript_available` is `false`, the response comes from the simulation backend.
+
+### List one mechanism
+
+Simulation request:
+
+```json
+{"mechanism": "condenser"}
+```
+
+On real hardware, replace `condenser` with an exact discovered identifier such as `C2` only when it appears in the live mechanism list.
+
+```python
+request = json.dumps({"mechanism": "condenser"})
+response = json.loads(microscope.aperture_list(request))
+```
+
+### Read the selected aperture
+
+```python
+request = json.dumps({"mechanism": "objective"})
+response = json.loads(microscope.aperture_get_selected(request))
+```
+
+### Read enabled or retractable status
+
+```python
+request = json.dumps({"mechanism": "objective"})
+enabled = json.loads(microscope.aperture_is_enabled(request))
+retractable = json.loads(microscope.aperture_is_retractable(request))
+```
+
+These are status reads only. They do not expose `enable()`, `disable()`, position movement, or centering.
+
+Expected response fields include:
+
+```json
+{
+  "ok": true,
+  "action": "get_selected",
+  "mechanism": "objective",
+  "aperture": {
+    "name": "40 um",
+    "type": "Circular",
+    "diameter_m": 0.00004
+  },
+  "insertion_state": "Inserted",
+  "autoscript_available": false,
+  "error": null
+}
+```
+
+Values shown above are simulation examples, not guaranteed Spectra hardware values.
+
+### Select by exact name
+
+First verify that the name occurs in the live `aperture_list` response. Then, while the microscope is idle and in the intended mode:
+
+```python
+request = json.dumps(
+    {
+        "mechanism": "objective",
+        "name": "100 um",
+    }
+)
+response = json.loads(microscope.aperture_select(request))
+if not response["ok"]:
+    raise RuntimeError(response["error"])
+```
+
+For real hardware, both strings must match the names discovered from AutoScript. The example names above belong to the simulator.
+
+### Insert or retract explicitly
+
+```python
+request = json.dumps({"mechanism": "selected_area"})
+
+insert_response = json.loads(microscope.aperture_insert(request))
+if not insert_response["ok"]:
+    raise RuntimeError(insert_response["error"])
+
+retract_response = json.loads(microscope.aperture_retract(request))
+if not retract_response["ok"]:
+    raise RuntimeError(retract_response["error"])
+```
+
+The current `AutoScriptMicroscope` path rejects these mutation commands during live acquisition. On real hardware, use the exact discovered mechanism identifier, such as `SA`, rather than assuming the simulation name `selected_area`.
+
+## Example microscopist workflows
+
+### Before STEM imaging
+
+1. Confirm that the microscope is in the intended STEM mode and is idle.
+2. Call `aperture_list("{}")` and identify the condenser mechanism reported by the real microscope.
+3. Call `aperture_get_selected()` for that mechanism.
+4. Verify the aperture name, diameter metadata, and insertion state against the intended probe-current and convergence condition.
+5. Make a change only through a separate explicit command.
+
+### Before diffraction or SAED
+
+1. Establish and verify the intended image/diffraction condition.
+2. Discover whether `SA` is available.
+3. Read the selected SA aperture and insertion state.
+4. Confirm the desired selected area before inserting or selecting another aperture.
+5. The command path rejects changes while a diffraction acquisition is active.
+
+### Before EDS or EELS
+
+1. Read the condenser, objective, and other relevant available aperture states.
+2. Preserve the returned JSON alongside the acquisition metadata so beam-current and collection conditions are traceable.
+3. AutoScriptMicroscope attaches the current aperture snapshot to saved STEM-image, camera-image, STEM-data, and EDS-spectrum metadata when it is available. A read failure is recorded under `errors` and does not stop the acquisition.
+4. For EELS, note that the supplied AutoScript documentation exposes energy-filter apertures through a separate API. The motorized mechanism commands described here do not implement EELS aperture support and do not touch `microscope.optics.energy_filter.apertures`.
+
+## Hardware-dependent behavior
+
+AutoScript support varies with microscope configuration and software version. The provided reference documents motorized `C1`, `C2`, `C3`, `Objective`, `SA`, and `TransferLens` mechanism identifiers, but the instrument's runtime discovery result is authoritative. A mechanism, aperture name, diameter, retractability, or position operation must never be assumed solely from this document or from simulation behavior.

--- a/startup_scripts/spectra_aperture_control_example.py
+++ b/startup_scripts/spectra_aperture_control_example.py
@@ -1,0 +1,121 @@
+"""Jupyter-friendly example for asyncroscopy Spectra aperture control.
+
+Run this file in a Jupyter console or an editor that supports ``# %%`` cells.
+Set ``TANGO_HOST`` for the Tango database before connecting, if needed.
+
+The example contains no Thermo Fisher reference-manual content.  It uses only
+the public asyncroscopy Tango JSON commands.
+"""
+
+# %% Imports and connection
+import json
+import os
+
+import tango
+
+
+MICROSCOPE_DEVICE = os.getenv(
+    "ASYNCROSCOPY_MICROSCOPE_DEVICE",
+    "asyncroscopy/autoscriptmicroscope/default",
+)
+
+microscope = tango.DeviceProxy(MICROSCOPE_DEVICE)
+microscope.ping()
+print("Connected:", MICROSCOPE_DEVICE)
+print("Device state:", microscope.state())
+
+
+def decode(response: str) -> dict:
+    """Decode and display one deterministic JSON command response."""
+    payload = json.loads(response)
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return payload
+
+
+# %% Safety check: always run read-only commands first
+# Safety rules:
+# - Confirm the microscope mode before changing any aperture.
+# - Do not change the objective or selected-area aperture during live acquisition.
+# - Verify the aperture name reported by the real Spectra before selecting it.
+# - Run the read-only list/get commands before enabling changes.
+print("STEM mode reported by microscope:", microscope.stem_mode)
+
+all_apertures = decode(microscope.aperture_list("{}"))
+mechanism_names = all_apertures.get("mechanisms", [])
+print("Available mechanisms:", mechanism_names)
+print("Using AutoScript hardware:", all_apertures["autoscript_available"])
+
+
+# %% List apertures for the four simulation-first mechanism categories
+# Real hardware discovery is authoritative. A real Spectra may report names
+# such as C1, C2, C3, Objective, or SA instead of these simulation categories.
+requested_mechanisms = (
+    "condenser",
+    "objective",
+    "selected_area",
+    "projector",
+)
+
+for mechanism in requested_mechanisms:
+    if mechanism not in mechanism_names:
+        print(f"Skipping {mechanism!r}: not reported by this microscope")
+        continue
+    request = json.dumps({"mechanism": mechanism})
+    decode(microscope.aperture_list(request))
+
+
+# %% Read the selected aperture without changing hardware
+for mechanism in requested_mechanisms:
+    if mechanism not in mechanism_names:
+        continue
+    request = json.dumps({"mechanism": mechanism})
+    decode(microscope.aperture_get_selected(request))
+
+
+# %% Explicit mutation example: disabled by default
+# Change these only after reviewing aperture_list() output from the real scope.
+TARGET_MECHANISM = "condenser"
+TARGET_APERTURE_NAME = "50 um"
+
+# Both flags must be intentionally changed after confirming the microscope is
+# idle and in the intended TEM/STEM mode. Never enable this during acquisition.
+CONFIRMED_MICROSCOPE_MODE_AND_IDLE = False
+ENABLE_APERTURE_CHANGES = False
+
+if CONFIRMED_MICROSCOPE_MODE_AND_IDLE and ENABLE_APERTURE_CHANGES:
+    # Re-read the live inventory immediately before changing anything.
+    inventory_request = json.dumps({"mechanism": TARGET_MECHANISM})
+    inventory = decode(microscope.aperture_list(inventory_request))
+    available_names = [item["name"] for item in inventory.get("apertures", [])]
+    if TARGET_APERTURE_NAME not in available_names:
+        raise ValueError(
+            f"Aperture {TARGET_APERTURE_NAME!r} was not reported for "
+            f"{TARGET_MECHANISM!r}. Available names: {available_names}"
+        )
+
+    # Select by the exact name returned by aperture_list().
+    select_request = json.dumps(
+        {
+            "mechanism": TARGET_MECHANISM,
+            "name": TARGET_APERTURE_NAME,
+        }
+    )
+    decode(microscope.aperture_select(select_request))
+
+    # Insertion and retraction are separate, explicit user actions.
+    mechanism_request = json.dumps({"mechanism": TARGET_MECHANISM})
+    decode(microscope.aperture_insert(mechanism_request))
+    decode(microscope.aperture_retract(mechanism_request))
+
+    # Read status again after the requested changes.
+    decode(microscope.aperture_get_selected(mechanism_request))
+else:
+    print(
+        "Aperture-changing commands were not run. Confirm microscope mode, "
+        "stop live acquisition, verify the reported aperture name, and then "
+        "explicitly enable both safety flags."
+    )
+
+
+# %% Final read-only status snapshot
+decode(microscope.aperture_list("{}"))

--- a/startup_scripts/spectra_aperture_dry_run.py
+++ b/startup_scripts/spectra_aperture_dry_run.py
@@ -1,0 +1,164 @@
+"""Read-only AutoScript aperture inventory for a Spectra microscope PC.
+
+Run this script first on the Spectra PC and save its terminal output. The
+printed mechanism and aperture names are the values to use in later
+``aperture_select`` requests.
+
+This module does not import AutoScript until ``main()`` requests a connection,
+so importing it or displaying ``--help`` does not require proprietary Thermo
+Fisher packages on a development machine.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from typing import Any
+
+
+DEFAULT_HOST = "10.46.217.241"
+DEFAULT_PORT = 9095
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Read the Spectra aperture inventory without changing hardware.",
+        epilog=(
+            "Run this first on the Spectra PC, save the terminal output, and use "
+            "the printed aperture names in future aperture_select commands."
+        ),
+    )
+    parser.add_argument(
+        "--host",
+        default=os.getenv("ASYNCROSCOPY_HARDWARE_HOST", DEFAULT_HOST),
+        help="AutoScript server host (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.getenv("ASYNCROSCOPY_HARDWARE_PORT", str(DEFAULT_PORT))),
+        help="AutoScript server port (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--confirm-write",
+        action="store_true",
+        help=(
+            "Reserved for a future write-enabled script. This version remains "
+            "strictly read-only even when supplied."
+        ),
+    )
+    return parser
+
+
+def connect_autoscript(host: str, port: int) -> Any:
+    """Create and connect the client using AutoScriptMicroscope's host/port pattern."""
+    try:
+        from autoscript_tem_microscope_client import TemMicroscopeClient
+    except ImportError as exc:
+        raise RuntimeError(
+            "AutoScript is unavailable. Run this script in the AutoScript Python "
+            "environment on the Spectra microscope PC. Missing import: "
+            "autoscript_tem_microscope_client.TemMicroscopeClient"
+        ) from exc
+
+    microscope = TemMicroscopeClient()
+    try:
+        microscope.connect(host, port)
+    except Exception as exc:
+        raise RuntimeError(
+            f"Could not connect to the AutoScript server at {host}:{port}: {exc}"
+        ) from exc
+    return microscope
+
+
+def format_diameter(diameter_m: float | None) -> str:
+    if diameter_m is None:
+        return "None"
+    return f"{diameter_m:.9g} m ({diameter_m * 1e6:.6g} um)"
+
+
+def print_mechanism(adapter: Any, mechanism: str) -> None:
+    """Print one mechanism while containing property errors to that mechanism."""
+    print(f"\nMechanism: {mechanism}")
+
+    try:
+        insertion_state = adapter.get_insertion_state(mechanism)
+        print(f"  insertion_state: {insertion_state}")
+    except Exception as exc:
+        print(f"  ERROR reading ApertureMechanism.insertion_state: {exc}")
+
+    try:
+        apertures = adapter.list_apertures(mechanism)
+    except Exception as exc:
+        print(f"  ERROR reading ApertureMechanism.apertures: {exc}")
+        return
+
+    print("  available apertures:")
+    if not apertures:
+        print("    (none reported)")
+    for aperture in apertures:
+        marker = " [SELECTED]" if aperture.selected else ""
+        print(f"    name: {aperture.name}{marker}")
+        print(f"      type: {aperture.aperture_type}")
+        print(f"      diameter: {format_diameter(aperture.diameter_m)}")
+
+    selected = next((item for item in apertures if item.selected), None)
+    if selected is None:
+        print("  selected aperture: None")
+    else:
+        print(f"  selected aperture: {selected.name}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    print("Spectra AutoScript aperture dry run")
+    print("Mode: READ ONLY")
+    print(f"Connection target: {args.host}:{args.port}")
+    if args.confirm_write:
+        print(
+            "--confirm-write acknowledged, but write operations are not implemented "
+            "in this script. No hardware changes will be made."
+        )
+
+    try:
+        microscope = connect_autoscript(args.host, args.port)
+    except RuntimeError as exc:
+        print("AutoScript available: no")
+        print(f"ERROR: {exc}")
+        return 2
+
+    print("AutoScript available: yes")
+
+    # Import after connection so development machines can still import this
+    # script and use --help without an AutoScript installation.
+    from asyncroscopy.instruments.electron_microscope.adapters.autoscript_apertures import (
+        AutoScriptApertureAdapter,
+    )
+
+    adapter = AutoScriptApertureAdapter(microscope)
+    try:
+        mechanisms = adapter.list_mechanisms()
+    except Exception as exc:
+        print(
+            "ERROR reading "
+            "microscope.optics.aperture_mechanisms.get_available: "
+            f"{exc}"
+        )
+        return 3
+
+    print(f"Discovered aperture mechanisms ({len(mechanisms)}):")
+    for mechanism in mechanisms:
+        print(f"  - {mechanism}")
+
+    for mechanism in mechanisms:
+        print_mechanism(adapter, mechanism)
+
+    print("\nDry run complete. No aperture was selected, inserted, retracted, or moved.")
+    print("Save this terminal output for the aperture automation configuration record.")
+    print("Use the exact printed names in future aperture_select commands.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ from tango.test_context import MultiDeviceTestContext
 from asyncroscopy.instruments.electron_microscope.detectors.camera import CAMERA
 from asyncroscopy.instruments.electron_microscope.detectors.eds import EDS
 from asyncroscopy.instruments.electron_microscope.detectors.flucam import FLUCAM
+from asyncroscopy.instruments.electron_microscope.hardware.aperture import APERTURE
 from asyncroscopy.instruments.electron_microscope.hardware.scan import SCAN
 from asyncroscopy.instruments.electron_microscope.hardware.stage import STAGE
 from asyncroscopy.instruments.electron_microscope.digital_twin import DigitalTwin
@@ -47,6 +48,15 @@ def tango_ctx(data_save_dir):
     Device names here MUST match what you put into STEMMicroscope properties.
     """
     devices_info = [
+        {
+            "class": APERTURE,
+            "devices": [
+                {
+                    "name": "asyncroscopy/aperture/default",
+                    "properties": {},
+                }
+            ],
+        },
         {
             "class": SCAN,
             "devices": [
@@ -178,6 +188,13 @@ def flucam_proxy(tango_ctx):
 @pytest.fixture(scope="session")
 def stage_proxy(tango_ctx):
     return tango.DeviceProxy(tango_ctx.get_device_access("asyncroscopy/stage/default"))
+
+
+@pytest.fixture
+def aperture_proxy(tango_ctx):
+    proxy = tango.DeviceProxy(tango_ctx.get_device_access("asyncroscopy/aperture/default"))
+    proxy.Init()
+    return proxy
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_aperture.py
+++ b/tests/test_aperture.py
@@ -1,0 +1,115 @@
+import json
+
+import pytest
+import tango
+
+from asyncroscopy.instruments.electron_microscope.hardware.aperture import ApertureInfo
+
+
+EXPECTED_MECHANISMS = ["condenser", "objective", "selected_area", "projector"]
+
+
+def test_aperture_info_model_is_typed() -> None:
+    aperture = ApertureInfo(
+        mechanism="condenser",
+        name="50 um",
+        aperture_type="Circular",
+        diameter_m=50e-6,
+        inserted=True,
+        selected=True,
+    )
+
+    assert aperture.diameter_m == pytest.approx(50e-6)
+    assert aperture.selected is True
+
+
+def test_list_apertures(aperture_proxy: tango.DeviceProxy) -> None:
+    response = json.loads(aperture_proxy.list_apertures())
+
+    assert response["status"] == "ok"
+    assert response["mechanism"] == "all"
+    assert response["selected_aperture"] is None
+    assert response["inserted"] is None
+    assert response["error"] is None
+    assert list(aperture_proxy.mechanism_names) == EXPECTED_MECHANISMS
+    assert {item["mechanism"] for item in response["apertures"]} == set(EXPECTED_MECHANISMS)
+    assert all("name" in item and "diameter_m" in item for item in response["apertures"])
+
+
+def test_get_selected_aperture(aperture_proxy: tango.DeviceProxy) -> None:
+    response = json.loads(aperture_proxy.get_selected_aperture("condenser"))
+
+    assert response["status"] == "ok"
+    assert response["mechanism"] == "condenser"
+    assert response["inserted"] is True
+    assert response["selected_aperture"]["name"] == "50 um"
+    assert response["selected_aperture"]["selected"] is True
+    assert aperture_proxy.selected_aperture_name == "50 um"
+    assert aperture_proxy.selected_aperture_type == "Circular"
+    assert aperture_proxy.selected_aperture_diameter_m == pytest.approx(50e-6)
+    assert aperture_proxy.insertion_state == "Inserted"
+
+
+def test_select_aperture_by_valid_name(aperture_proxy: tango.DeviceProxy) -> None:
+    request = json.dumps({"mechanism": "condenser", "name": "70 um"})
+    response = json.loads(aperture_proxy.select_aperture(request))
+
+    assert response["status"] == "ok"
+    assert response["mechanism"] == "condenser"
+    assert response["selected_aperture"]["name"] == "70 um"
+    assert response["selected_aperture"]["diameter_m"] == pytest.approx(70e-6)
+    assert response["inserted"] is True
+    assert response["error"] is None
+
+
+def test_reject_invalid_mechanism(aperture_proxy: tango.DeviceProxy) -> None:
+    response = json.loads(aperture_proxy.get_selected_aperture("not_a_mechanism"))
+
+    assert response["status"] == "error"
+    assert response["mechanism"] == "not_a_mechanism"
+    assert response["selected_aperture"] is None
+    assert response["inserted"] is None
+    assert "Unknown aperture mechanism" in response["error"]
+    assert aperture_proxy.last_error == response["error"]
+
+
+def test_reject_invalid_aperture_name(aperture_proxy: tango.DeviceProxy) -> None:
+    request = json.dumps({"mechanism": "condenser", "name": "999 um"})
+    response = json.loads(aperture_proxy.select_aperture(request))
+
+    assert response["status"] == "error"
+    assert response["mechanism"] == "condenser"
+    assert "Unknown aperture" in response["error"]
+    assert "999 um" in response["error"]
+
+
+def test_insert_and_retract_mechanism(aperture_proxy: tango.DeviceProxy) -> None:
+    initial = json.loads(aperture_proxy.get_selected_aperture("objective"))
+    assert initial["inserted"] is False
+    assert initial["selected_aperture"] is None
+
+    inserted = json.loads(aperture_proxy.insert_mechanism("objective"))
+    assert inserted["status"] == "ok"
+    assert inserted["inserted"] is True
+    assert inserted["selected_aperture"]["name"] == "40 um"
+
+    retracted = json.loads(aperture_proxy.retract_mechanism("objective"))
+    assert retracted["status"] == "ok"
+    assert retracted["inserted"] is False
+    assert retracted["selected_aperture"] is None
+    assert aperture_proxy.insertion_state == "Retracted"
+
+
+def test_json_responses_are_deterministic(aperture_proxy: tango.DeviceProxy) -> None:
+    first_list = aperture_proxy.list_apertures()
+    second_list = aperture_proxy.list_apertures()
+    first_refresh = aperture_proxy.refresh()
+    second_refresh = aperture_proxy.refresh()
+
+    assert first_list == second_list
+    assert first_refresh == second_refresh
+    assert first_list == json.dumps(
+        json.loads(first_list),
+        sort_keys=True,
+        separators=(",", ":"),
+    )

--- a/tests/test_aperture_metadata.py
+++ b/tests/test_aperture_metadata.py
@@ -1,0 +1,107 @@
+import json
+import types
+
+import h5py
+import numpy as np
+
+from asyncroscopy.instruments.electron_microscope.auto_script import AutoScriptMicroscope
+from asyncroscopy.instruments.electron_microscope.hardware.aperture import (
+    SimulatedApertureBackend,
+)
+
+
+class FakeDataServer:
+    def register_path(self, path: str) -> str:
+        return path
+
+
+class FakeImage:
+    data = np.array([[1, 2], [3, 4]], dtype=np.uint16)
+
+
+class FakeAcquisition:
+    def acquire_stem_images_advanced(self, settings):
+        return [FakeImage()]
+
+
+class FailingApertureAdapter:
+    def list_mechanisms(self):
+        raise RuntimeError("simulated aperture read failure")
+
+
+def make_microscope(adapter) -> AutoScriptMicroscope:
+    microscope = AutoScriptMicroscope.__new__(AutoScriptMicroscope)
+    microscope._microscope = types.SimpleNamespace(acquisition=FakeAcquisition())
+    microscope._detector_proxies = {"data": FakeDataServer()}
+    microscope._aperture_adapter = adapter
+    microscope._aperture_autoscript_available = False
+    return microscope
+
+
+def test_aperture_metadata_is_deterministic() -> None:
+    microscope = make_microscope(SimulatedApertureBackend())
+
+    first = microscope._get_aperture_metadata()
+    second = microscope._get_aperture_metadata()
+
+    assert first == second
+    assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+    assert first["mechanisms"] == [
+        "condenser",
+        "objective",
+        "selected_area",
+        "projector",
+    ]
+    assert first["selected_apertures"]["condenser"]["name"] == "50 um"
+    assert first["insertion_states"]["condenser"] == "Inserted"
+    assert first["errors"] == {}
+
+
+def test_acquisition_hdf5_includes_aperture_metadata(monkeypatch, tmp_path) -> None:
+    microscope = make_microscope(SimulatedApertureBackend())
+
+    def fake_filename(device, acquisition_type, detector, data_server=None, extension="h5"):
+        return tmp_path / "stem_with_apertures.h5"
+
+    monkeypatch.setattr(
+        "asyncroscopy.data.data_writer.acquisition_filename",
+        fake_filename,
+    )
+
+    result = microscope._acquire_scanned_image(
+        imsize=2,
+        dwell_time=1e-6,
+        detector_list=["haadf"],
+        scan_region=[0.0, 0.0, 1.0, 1.0],
+    )
+
+    with h5py.File(result, "r") as h5:
+        aperture_metadata = json.loads(h5.attrs["apertures"])
+    assert aperture_metadata["source"] == "simulation"
+    assert aperture_metadata["selected_apertures"]["condenser"]["name"] == "50 um"
+    assert aperture_metadata["insertion_states"]["objective"] == "Retracted"
+
+
+def test_aperture_read_failure_does_not_fail_acquisition(monkeypatch, tmp_path) -> None:
+    microscope = make_microscope(FailingApertureAdapter())
+
+    def fake_filename(device, acquisition_type, detector, data_server=None, extension="h5"):
+        return tmp_path / "stem_with_aperture_error.h5"
+
+    monkeypatch.setattr(
+        "asyncroscopy.data.data_writer.acquisition_filename",
+        fake_filename,
+    )
+
+    result = microscope._acquire_scanned_image(
+        imsize=2,
+        dwell_time=1e-6,
+        detector_list=["haadf"],
+        scan_region=[0.0, 0.0, 1.0, 1.0],
+    )
+
+    with h5py.File(result, "r") as h5:
+        aperture_metadata = json.loads(h5.attrs["apertures"])
+        assert h5["image/HAADF"].shape == (2, 2)
+    assert aperture_metadata["mechanisms"] == []
+    assert "simulated aperture read failure" in aperture_metadata["errors"]["adapter"]

--- a/tests/test_auto_script_aperture_commands.py
+++ b/tests/test_auto_script_aperture_commands.py
@@ -1,0 +1,567 @@
+import json
+import types
+import subprocess
+import sys
+
+import pytest
+import tango
+
+from asyncroscopy.instruments.electron_microscope.auto_script import AutoScriptMicroscope
+from asyncroscopy.instruments.electron_microscope.hardware.aperture import ApertureInfo
+
+
+RESPONSE_FIELDS = {
+    "ok",
+    "action",
+    "mechanism",
+    "aperture",
+    "insertion_state",
+    "autoscript_available",
+    "error",
+}
+
+
+@pytest.fixture
+def simulated_autoscript_proxy(auto_script_proxy: tango.DeviceProxy) -> tango.DeviceProxy:
+    auto_script_proxy.Init()
+    return auto_script_proxy
+
+
+def test_auto_script_microscope_imports_when_autoscript_is_blocked() -> None:
+    script = r'''
+import builtins
+
+original_import = builtins.__import__
+
+def blocked_import(name, *args, **kwargs):
+    if name.startswith("autoscript_tem_microscope_client"):
+        raise ImportError("AutoScript deliberately unavailable")
+    return original_import(name, *args, **kwargs)
+
+builtins.__import__ = blocked_import
+from asyncroscopy.instruments.electron_microscope import auto_script
+assert auto_script._AUTOSCRIPT_AVAILABLE is False
+'''
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_testing_mode_aperture_list_uses_simulation(
+    simulated_autoscript_proxy: tango.DeviceProxy,
+) -> None:
+    response = json.loads(simulated_autoscript_proxy.aperture_list("{}"))
+
+    assert RESPONSE_FIELDS.issubset(response)
+    assert response["ok"] is True
+    assert response["action"] == "list"
+    assert response["mechanism"] == "all"
+    assert response["autoscript_available"] is False
+    assert response["error"] is None
+    assert response["mechanisms"] == [
+        "condenser",
+        "objective",
+        "selected_area",
+        "projector",
+    ]
+
+
+def test_testing_mode_gets_selected_aperture(
+    simulated_autoscript_proxy: tango.DeviceProxy,
+) -> None:
+    request = json.dumps({"mechanism": "condenser"})
+    response = json.loads(simulated_autoscript_proxy.aperture_get_selected(request))
+
+    assert response["ok"] is True
+    assert response["action"] == "get_selected"
+    assert response["mechanism"] == "condenser"
+    assert response["aperture"] == {
+        "name": "50 um",
+        "type": "Circular",
+        "diameter_m": pytest.approx(50e-6),
+    }
+    assert response["insertion_state"] == "Inserted"
+    assert response["autoscript_available"] is False
+
+
+def test_aperture_command_rejects_invalid_json(
+    simulated_autoscript_proxy: tango.DeviceProxy,
+) -> None:
+    response = json.loads(simulated_autoscript_proxy.aperture_get_selected("not-json"))
+
+    assert response["ok"] is False
+    assert response["action"] == "get_selected"
+    assert response["mechanism"] == ""
+    assert response["error"] == "Invalid JSON request."
+
+
+def test_aperture_command_requires_mechanism(
+    simulated_autoscript_proxy: tango.DeviceProxy,
+) -> None:
+    response = json.loads(simulated_autoscript_proxy.aperture_insert("{}"))
+
+    assert response["ok"] is False
+    assert response["error"] == (
+        "Aperture request requires a non-empty string 'mechanism'."
+    )
+
+
+def test_aperture_select_requires_name(
+    simulated_autoscript_proxy: tango.DeviceProxy,
+) -> None:
+    request = json.dumps({"mechanism": "objective"})
+    response = json.loads(simulated_autoscript_proxy.aperture_select(request))
+
+    assert response["ok"] is False
+    assert response["mechanism"] == "objective"
+    assert response["error"] == "Aperture request requires a non-empty string 'name'."
+
+
+def test_testing_mode_reads_enabled_status(
+    simulated_autoscript_proxy: tango.DeviceProxy,
+) -> None:
+    request = json.dumps({"mechanism": "condenser"})
+    response = json.loads(simulated_autoscript_proxy.aperture_is_enabled(request))
+
+    assert response["ok"] is True
+    assert response["action"] == "is_enabled"
+    assert response["mechanism"] == "condenser"
+    assert response["enabled"] is True
+    assert response["autoscript_available"] is False
+    assert response["error"] is None
+
+
+def test_testing_mode_reads_retractable_status(
+    simulated_autoscript_proxy: tango.DeviceProxy,
+) -> None:
+    request = json.dumps({"mechanism": "objective"})
+    response = json.loads(simulated_autoscript_proxy.aperture_is_retractable(request))
+
+    assert response["ok"] is True
+    assert response["action"] == "is_retractable"
+    assert response["mechanism"] == "objective"
+    assert response["retractable"] is True
+    assert response["autoscript_available"] is False
+    assert response["error"] is None
+
+
+def test_aperture_status_rejects_unknown_mechanism(
+    simulated_autoscript_proxy: tango.DeviceProxy,
+) -> None:
+    request = json.dumps({"mechanism": "not_a_mechanism"})
+    response = json.loads(simulated_autoscript_proxy.aperture_is_enabled(request))
+
+    assert response["ok"] is False
+    assert response["action"] == "is_enabled"
+    assert response["mechanism"] == "not_a_mechanism"
+    assert "Unknown aperture mechanism" in response["error"]
+
+
+def test_testing_mode_select_returns_selected_aperture(
+    simulated_autoscript_proxy: tango.DeviceProxy,
+) -> None:
+    request = json.dumps({"mechanism": "objective", "name": "100 um"})
+    response = json.loads(simulated_autoscript_proxy.aperture_select(request))
+
+    assert response["ok"] is True
+    assert response["action"] == "select"
+    assert response["mechanism"] == "objective"
+    assert response["aperture"] == {
+        "name": "100 um",
+        "type": "Circular",
+        "diameter_m": pytest.approx(100e-6),
+    }
+    assert response["insertion_state"] == "Inserted"
+    assert response["autoscript_available"] is False
+    assert response["error"] is None
+
+
+def test_testing_mode_insert_and_retract_are_explicit(
+    simulated_autoscript_proxy: tango.DeviceProxy,
+) -> None:
+    request = json.dumps({"mechanism": "selected_area"})
+
+    inserted = json.loads(simulated_autoscript_proxy.aperture_insert(request))
+    retracted = json.loads(simulated_autoscript_proxy.aperture_retract(request))
+
+    assert inserted["ok"] is True
+    assert inserted["action"] == "insert"
+    assert inserted["insertion_state"] == "Inserted"
+    assert inserted["aperture"] is not None
+    assert retracted["ok"] is True
+    assert retracted["action"] == "retract"
+    assert retracted["insertion_state"] == "Retracted"
+    assert retracted["aperture"] is None
+
+class RecordingApertureBackend:
+    def __init__(self, *, enabled: bool = True, retractable: bool = True) -> None:
+        self.enabled = enabled
+        self.retractable = retractable
+        self.select_calls = 0
+        self.insert_calls = 0
+        self.retract_calls = 0
+        self.enable_calls = 0
+        self.disable_calls = 0
+        self.insertion_state = "Retracted"
+
+    def is_enabled(self, mechanism: str) -> bool:
+        return self.enabled
+
+    def is_retractable(self, mechanism: str) -> bool:
+        return self.retractable
+
+    def _aperture(self, mechanism: str, name: str = "50 um") -> ApertureInfo:
+        return ApertureInfo(
+            mechanism=mechanism,
+            name=name,
+            aperture_type="Circular",
+            diameter_m=50e-6,
+            inserted=True,
+            selected=True,
+        )
+
+    def enable(self, mechanism: str) -> bool:
+        self.enable_calls += 1
+        self.enabled = True
+        return self.enabled
+
+    def disable(self, mechanism: str) -> bool:
+        self.disable_calls += 1
+        self.enabled = False
+        return self.enabled
+
+    def list_mechanisms(self) -> list[str]:
+        return ["C2"]
+
+    def list_apertures(self, mechanism: str) -> list[ApertureInfo]:
+        return [self._aperture(mechanism)]
+
+    def select_aperture(self, mechanism: str, name: str) -> ApertureInfo:
+        self.select_calls += 1
+        return self._aperture(mechanism, name)
+
+    def insert_mechanism(self, mechanism: str) -> str:
+        self.insert_calls += 1
+        return "Inserted"
+
+    def retract_mechanism(self, mechanism: str) -> str:
+        self.retract_calls += 1
+        return "Retracted"
+
+    def get_selected_aperture(self, mechanism: str) -> ApertureInfo:
+        return self._aperture(mechanism)
+
+    def get_insertion_state(self, mechanism: str) -> str:
+        return self.insertion_state
+
+
+class MissingEnableBackend(RecordingApertureBackend):
+    enable = None
+
+
+class MissingDisableBackend(RecordingApertureBackend):
+    disable = None
+
+
+class MissingEnabledBackend(RecordingApertureBackend):
+    is_enabled = None
+
+
+class MissingRetractableBackend(RecordingApertureBackend):
+    is_retractable = None
+
+
+def make_direct_microscope(adapter) -> AutoScriptMicroscope:
+    microscope = AutoScriptMicroscope.__new__(AutoScriptMicroscope)
+    microscope._aperture_adapter = adapter
+    microscope._aperture_autoscript_available = False
+    microscope.error_stream = lambda message: None
+    microscope.info_stream = lambda message: None
+    microscope._acquisition_active = False
+    return microscope
+
+
+
+def test_acquisition_command_marks_acquisition_active_until_complete() -> None:
+    microscope = make_direct_microscope(RecordingApertureBackend())
+    microscope._detector_proxies = {
+        "scan": types.SimpleNamespace(
+            imsize=16,
+            dwell_time=1e-6,
+            scan_region=[0.0, 0.0, 1.0, 1.0],
+            output_format=".h5",
+        )
+    }
+
+    def fake_acquire(imsize, dwell_time, detector_list, scan_region, output_format):
+        assert microscope._acquisition_active is True
+        return "acquired-key"
+
+    microscope._acquire_scanned_image = fake_acquire
+
+    result = microscope.acquire_scanned_image(["haadf"])
+
+    assert result == "acquired-key"
+    assert microscope._acquisition_active is False
+
+
+def test_aperture_mutations_are_blocked_during_active_acquisition() -> None:
+    adapter = RecordingApertureBackend(enabled=True, retractable=True)
+    microscope = make_direct_microscope(adapter)
+    microscope._acquisition_active = True
+
+    responses = [
+        json.loads(
+            microscope.aperture_select(json.dumps({"mechanism": "C2", "name": "70 um"}))
+        ),
+        json.loads(microscope.aperture_insert(json.dumps({"mechanism": "C2"}))),
+        json.loads(microscope.aperture_retract(json.dumps({"mechanism": "C2"}))),
+        json.loads(microscope.aperture_enable(json.dumps({"mechanism": "C2"}))),
+        json.loads(microscope.aperture_disable(json.dumps({"mechanism": "C2"}))),
+    ]
+
+    assert all(response["ok"] is False for response in responses)
+    assert all(
+        "aperture mutation is blocked because acquisition is active"
+        in response["error"].lower()
+        for response in responses
+    )
+    assert adapter.select_calls == 0
+    assert adapter.insert_calls == 0
+    assert adapter.retract_calls == 0
+    assert adapter.enable_calls == 0
+    assert adapter.disable_calls == 0
+
+
+def test_aperture_mutation_is_allowed_when_acquisition_is_idle() -> None:
+    adapter = RecordingApertureBackend(enabled=True, retractable=True)
+    microscope = make_direct_microscope(adapter)
+    microscope._acquisition_active = False
+
+    response = json.loads(
+        microscope.aperture_select(json.dumps({"mechanism": "C2", "name": "70 um"}))
+    )
+
+    assert response["ok"] is True
+    assert adapter.select_calls == 1
+
+
+def test_read_only_aperture_commands_are_allowed_during_active_acquisition() -> None:
+    adapter = RecordingApertureBackend(enabled=False, retractable=False)
+    microscope = make_direct_microscope(adapter)
+    microscope._acquisition_active = True
+
+    listed = json.loads(microscope.aperture_list("{}"))
+    selected = json.loads(microscope.aperture_get_selected(json.dumps({"mechanism": "C2"})))
+    enabled = json.loads(microscope.aperture_is_enabled(json.dumps({"mechanism": "C2"})))
+    retractable = json.loads(
+        microscope.aperture_is_retractable(json.dumps({"mechanism": "C2"}))
+    )
+
+    assert listed["ok"] is True
+    assert selected["ok"] is True
+    assert enabled["ok"] is True
+    assert enabled["enabled"] is False
+    assert retractable["ok"] is True
+    assert retractable["retractable"] is False
+
+def test_select_is_rejected_when_mechanism_is_disabled() -> None:
+    adapter = RecordingApertureBackend(enabled=False)
+    microscope = make_direct_microscope(adapter)
+
+    response = json.loads(
+        microscope.aperture_select(json.dumps({"mechanism": "C2", "name": "50 um"}))
+    )
+
+    assert response["ok"] is False
+    assert "disabled" in response["error"]
+    assert adapter.select_calls == 0
+
+
+def test_insert_is_rejected_when_mechanism_is_disabled() -> None:
+    adapter = RecordingApertureBackend(enabled=False)
+    microscope = make_direct_microscope(adapter)
+
+    response = json.loads(microscope.aperture_insert(json.dumps({"mechanism": "C2"})))
+
+    assert response["ok"] is False
+    assert "disabled" in response["error"]
+    assert adapter.insert_calls == 0
+
+
+def test_retract_is_rejected_when_mechanism_is_disabled() -> None:
+    adapter = RecordingApertureBackend(enabled=False)
+    microscope = make_direct_microscope(adapter)
+
+    response = json.loads(microscope.aperture_retract(json.dumps({"mechanism": "C2"})))
+
+    assert response["ok"] is False
+    assert "disabled" in response["error"]
+    assert adapter.retract_calls == 0
+
+
+def test_insert_is_rejected_when_mechanism_is_not_retractable() -> None:
+    adapter = RecordingApertureBackend(enabled=True, retractable=False)
+    microscope = make_direct_microscope(adapter)
+
+    response = json.loads(microscope.aperture_insert(json.dumps({"mechanism": "C2"})))
+
+    assert response["ok"] is False
+    assert "not retractable" in response["error"]
+    assert adapter.insert_calls == 0
+
+
+def test_retract_is_rejected_when_mechanism_is_not_retractable() -> None:
+    adapter = RecordingApertureBackend(enabled=True, retractable=False)
+    microscope = make_direct_microscope(adapter)
+
+    response = json.loads(microscope.aperture_retract(json.dumps({"mechanism": "C2"})))
+
+    assert response["ok"] is False
+    assert "not retractable" in response["error"]
+    assert adapter.retract_calls == 0
+
+
+def test_successful_mutations_still_call_backend() -> None:
+    adapter = RecordingApertureBackend(enabled=True, retractable=True)
+    microscope = make_direct_microscope(adapter)
+
+    select = json.loads(
+        microscope.aperture_select(json.dumps({"mechanism": "C2", "name": "70 um"}))
+    )
+    insert = json.loads(microscope.aperture_insert(json.dumps({"mechanism": "C2"})))
+    retract = json.loads(microscope.aperture_retract(json.dumps({"mechanism": "C2"})))
+
+    assert select["ok"] is True
+    assert insert["ok"] is True
+    assert retract["ok"] is True
+    assert adapter.select_calls == 1
+    assert adapter.insert_calls == 1
+    assert adapter.retract_calls == 1
+
+
+def test_read_only_status_commands_still_work_with_false_values() -> None:
+    adapter = RecordingApertureBackend(enabled=False, retractable=False)
+    microscope = make_direct_microscope(adapter)
+
+    enabled = json.loads(microscope.aperture_is_enabled(json.dumps({"mechanism": "C2"})))
+    retractable = json.loads(
+        microscope.aperture_is_retractable(json.dumps({"mechanism": "C2"}))
+    )
+
+    assert enabled["ok"] is True
+    assert enabled["enabled"] is False
+    assert retractable["ok"] is True
+    assert retractable["retractable"] is False
+
+
+def test_select_reports_missing_enabled_status_before_backend_call() -> None:
+    adapter = MissingEnabledBackend()
+    microscope = make_direct_microscope(adapter)
+
+    response = json.loads(
+        microscope.aperture_select(json.dumps({"mechanism": "C2", "name": "50 um"}))
+    )
+
+    assert response["ok"] is False
+    assert "unsupported or missing" in response["error"]
+    assert "is_enabled" in response["error"]
+    assert adapter.select_calls == 0
+
+
+def test_insert_reports_missing_retractable_status_before_backend_call() -> None:
+    adapter = MissingRetractableBackend()
+    microscope = make_direct_microscope(adapter)
+
+    response = json.loads(microscope.aperture_insert(json.dumps({"mechanism": "C2"})))
+
+    assert response["ok"] is False
+    assert "unsupported or missing" in response["error"]
+    assert "is_retractable" in response["error"]
+    assert adapter.insert_calls == 0
+
+def test_enable_calls_backend_enable_and_updates_status() -> None:
+    adapter = RecordingApertureBackend(enabled=False)
+    microscope = make_direct_microscope(adapter)
+
+    response = json.loads(microscope.aperture_enable(json.dumps({"mechanism": "C2"})))
+    status = json.loads(microscope.aperture_is_enabled(json.dumps({"mechanism": "C2"})))
+
+    assert response["ok"] is True
+    assert response["enabled"] is True
+    assert status["enabled"] is True
+    assert adapter.enable_calls == 1
+
+
+def test_disable_calls_backend_disable_and_updates_status() -> None:
+    adapter = RecordingApertureBackend(enabled=True)
+    adapter.insertion_state = "Retracted"
+    microscope = make_direct_microscope(adapter)
+
+    response = json.loads(microscope.aperture_disable(json.dumps({"mechanism": "C2"})))
+    status = json.loads(microscope.aperture_is_enabled(json.dumps({"mechanism": "C2"})))
+
+    assert response["ok"] is True
+    assert response["enabled"] is False
+    assert status["enabled"] is False
+    assert adapter.disable_calls == 1
+
+
+def test_disable_rejects_inserted_mechanism_before_backend_call() -> None:
+    adapter = RecordingApertureBackend(enabled=True)
+    adapter.insertion_state = "Inserted"
+    microscope = make_direct_microscope(adapter)
+
+    response = json.loads(microscope.aperture_disable(json.dumps({"mechanism": "C2"})))
+
+    assert response["ok"] is False
+    assert "not safe to disable" in response["error"]
+    assert "Inserted" in response["error"]
+    assert adapter.disable_calls == 0
+
+
+def test_enable_reports_missing_backend_method() -> None:
+    adapter = MissingEnableBackend(enabled=False)
+    microscope = make_direct_microscope(adapter)
+
+    response = json.loads(microscope.aperture_enable(json.dumps({"mechanism": "C2"})))
+
+    assert response["ok"] is False
+    assert "unsupported" in response["error"].lower()
+    assert "enable" in response["error"]
+    assert adapter.enable_calls == 0
+
+
+def test_disable_reports_missing_backend_method() -> None:
+    adapter = MissingDisableBackend(enabled=True)
+    microscope = make_direct_microscope(adapter)
+
+    response = json.loads(microscope.aperture_disable(json.dumps({"mechanism": "C2"})))
+
+    assert response["ok"] is False
+    assert "unsupported" in response["error"].lower()
+    assert "disable" in response["error"]
+    assert adapter.disable_calls == 0
+
+
+def test_enable_unknown_mechanism_gives_clear_error() -> None:
+    class UnknownMechanismBackend(RecordingApertureBackend):
+        def enable(self, mechanism: str) -> bool:
+            raise ValueError(
+                f"Unknown aperture mechanism {mechanism!r}. Available mechanisms: C2."
+            )
+
+    adapter = UnknownMechanismBackend()
+    microscope = make_direct_microscope(adapter)
+
+    response = json.loads(
+        microscope.aperture_enable(json.dumps({"mechanism": "not_a_mechanism"}))
+    )
+
+    assert response["ok"] is False
+    assert "Unknown aperture mechanism" in response["error"]

--- a/tests/test_autoscript_apertures_adapter.py
+++ b/tests/test_autoscript_apertures_adapter.py
@@ -1,0 +1,235 @@
+from types import SimpleNamespace
+
+import pytest
+
+from asyncroscopy.instruments.electron_microscope.adapters.autoscript_apertures import (
+    AutoScriptApertureAdapter,
+)
+
+
+class FakeAperture:
+    def __init__(self, name: str, aperture_type: str, diameter: float | None):
+        self.name = name
+        self.type = aperture_type
+        self.diameter = diameter
+
+
+class FakeMechanism:
+    def __init__(self, *, is_enabled: bool = True, is_retractable: bool = True):
+        self.apertures = [
+            FakeAperture("30 um", "Circular", 30e-6),
+            FakeAperture("50 um", "Circular", 50e-6),
+            FakeAperture("Phase plate", "PhasePlate", None),
+        ]
+        self.aperture = self.apertures[0]
+        self.insertion_state = "Inserted"
+        self.is_enabled = is_enabled
+        self.is_retractable = is_retractable
+        self._position = SimpleNamespace(x=1e-6, y=-2e-6)
+        self.enable_calls = 0
+        self.disable_calls = 0
+
+    @property
+    def position(self):
+        return self._position
+
+    @position.setter
+    def position(self, value):
+        if isinstance(value, tuple):
+            self._position = SimpleNamespace(x=value[0], y=value[1])
+        else:
+            self._position = value
+
+    def enable(self) -> None:
+        self.enable_calls += 1
+        self.is_enabled = True
+
+    def disable(self) -> None:
+        self.disable_calls += 1
+        self.is_enabled = False
+    def insert(self) -> None:
+        self.insertion_state = "Inserted"
+
+    def retract(self) -> None:
+        self.insertion_state = "Retracted"
+        self.aperture = None
+
+
+class FakeCollection:
+    def __init__(self):
+        self.mechanisms = {
+            "C2": FakeMechanism(is_enabled=True, is_retractable=True),
+            "Objective": FakeMechanism(is_enabled=False, is_retractable=False),
+        }
+
+    def get_available(self) -> list[str]:
+        return list(self.mechanisms)
+
+    def get_mechanism(self, mechanism: str) -> FakeMechanism:
+        return self.mechanisms[mechanism]
+
+
+def make_adapter() -> tuple[AutoScriptApertureAdapter, FakeCollection]:
+    collection = FakeCollection()
+    microscope = SimpleNamespace(
+        optics=SimpleNamespace(aperture_mechanisms=collection)
+    )
+    return AutoScriptApertureAdapter(microscope), collection
+
+
+def test_adapter_lists_mechanisms() -> None:
+    adapter, _ = make_adapter()
+
+    assert adapter.list_mechanisms() == ["C2", "Objective"]
+
+
+def test_adapter_lists_apertures_with_name_type_and_diameter() -> None:
+    adapter, _ = make_adapter()
+
+    apertures = adapter.list_apertures("C2")
+
+    assert [item.name for item in apertures] == ["30 um", "50 um", "Phase plate"]
+    assert apertures[0].aperture_type == "Circular"
+    assert apertures[0].diameter_m == pytest.approx(30e-6)
+    assert apertures[0].inserted is True
+    assert apertures[0].selected is True
+    assert apertures[2].aperture_type == "PhasePlate"
+    assert apertures[2].diameter_m is None
+
+
+def test_adapter_selects_by_aperture_name() -> None:
+    adapter, collection = make_adapter()
+
+    selected = adapter.select_aperture("C2", "50 um")
+
+    assert selected.name == "50 um"
+    assert selected.aperture_type == "Circular"
+    assert selected.diameter_m == pytest.approx(50e-6)
+    assert collection.mechanisms["C2"].aperture is collection.mechanisms["C2"].apertures[1]
+
+
+def test_adapter_gets_selected_aperture() -> None:
+    adapter, _ = make_adapter()
+
+    selected = adapter.get_selected_aperture("C2")
+
+    assert selected.name == "30 um"
+    assert selected.selected is True
+
+
+def test_adapter_enable_and_disable_call_documented_methods() -> None:
+    adapter, collection = make_adapter()
+    mechanism = collection.mechanisms["Objective"]
+
+    assert adapter.enable("Objective") is True
+    assert mechanism.enable_calls == 1
+    assert mechanism.is_enabled is True
+
+    assert adapter.disable("Objective") is False
+    assert mechanism.disable_calls == 1
+    assert mechanism.is_enabled is False
+
+
+def test_adapter_reports_missing_enable_as_unsupported_operation() -> None:
+    adapter, collection = make_adapter()
+    collection.mechanisms["C2"].enable = None
+
+    with pytest.raises(
+        RuntimeError,
+        match="Unsupported AutoScript aperture operation 'enable'.*ApertureMechanism.enable",
+    ):
+        adapter.enable("C2")
+
+
+def test_adapter_reports_missing_disable_as_unsupported_operation() -> None:
+    adapter, collection = make_adapter()
+    collection.mechanisms["C2"].disable = None
+
+    with pytest.raises(
+        RuntimeError,
+        match="Unsupported AutoScript aperture operation 'disable'.*ApertureMechanism.disable",
+    ):
+        adapter.disable("C2")
+
+
+def test_adapter_enable_rejects_unknown_mechanism() -> None:
+    adapter, _ = make_adapter()
+
+    with pytest.raises(ValueError, match="Unknown AutoScript aperture mechanism 'C3'"):
+        adapter.enable("C3")
+
+def test_adapter_reads_insertion_state_and_controls_mechanism() -> None:
+    adapter, _ = make_adapter()
+
+    assert adapter.get_insertion_state("C2") == "Inserted"
+    assert adapter.retract_mechanism("C2") == "Retracted"
+    assert adapter.insert_mechanism("C2") == "Inserted"
+
+
+def test_adapter_reads_enabled_status() -> None:
+    adapter, _ = make_adapter()
+
+    assert adapter.is_enabled("C2") is True
+    assert adapter.is_enabled("Objective") is False
+
+
+def test_adapter_reads_retractable_status() -> None:
+    adapter, _ = make_adapter()
+
+    assert adapter.is_retractable("C2") is True
+    assert adapter.is_retractable("Objective") is False
+
+
+def test_adapter_reads_and_sets_documented_position() -> None:
+    adapter, _ = make_adapter()
+
+    assert adapter.get_position("C2") == pytest.approx((1e-6, -2e-6))
+
+    assert adapter.set_position("C2", 5e-6, -6e-6) == pytest.approx((5e-6, -6e-6))
+
+
+def test_adapter_rejects_missing_mechanism() -> None:
+    adapter, _ = make_adapter()
+
+    with pytest.raises(ValueError, match="Unknown AutoScript aperture mechanism 'C3'"):
+        adapter.list_apertures("C3")
+
+
+def test_adapter_rejects_unknown_aperture_name() -> None:
+    adapter, _ = make_adapter()
+
+    with pytest.raises(ValueError, match="Unknown aperture name '100 um'"):
+        adapter.select_aperture("C2", "100 um")
+
+
+def test_adapter_reports_missing_enabled_as_unsupported_operation() -> None:
+    adapter, collection = make_adapter()
+    del collection.mechanisms["C2"].is_enabled
+
+    with pytest.raises(
+        RuntimeError,
+        match="Unsupported AutoScript aperture operation 'is_enabled'.*ApertureMechanism.is_enabled",
+    ):
+        adapter.is_enabled("C2")
+
+
+def test_adapter_reports_missing_retractable_as_unsupported_operation() -> None:
+    adapter, collection = make_adapter()
+    del collection.mechanisms["C2"].is_retractable
+
+    with pytest.raises(
+        RuntimeError,
+        match="Unsupported AutoScript aperture operation 'is_retractable'.*ApertureMechanism.is_retractable",
+    ):
+        adapter.is_retractable("C2")
+
+
+def test_adapter_reports_missing_autoscript_property() -> None:
+    microscope = SimpleNamespace(optics=SimpleNamespace())
+    adapter = AutoScriptApertureAdapter(microscope)
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"microscope\.optics\.aperture_mechanisms",
+    ):
+        adapter.list_mechanisms()


### PR DESCRIPTION


This pull request adds aperture support through two new files:

* `aperture.py`
* `autoscript_apertures.py`

`aperture.py` defines the aperture device/backend structure, including commands for listing apertures, checking the selected aperture, selecting an aperture, inserting the mechanism, and retracting it.

`autoscript_apertures.py` adds the AutoScript adapter layer that connects asyncroscopy aperture commands to the microscope/AutoScript API.

## Purpose

The goal is to make aperture control available in asyncroscopy in a modular way, so aperture-related hardware logic is separated from the higher-level microscope workflow.

## Notes

This is intended as an initial aperture-control implementation and can be extended further after testing with the real microscope setup.
