### PR TITLE
Updates to AI Agent testing notebook and fixes to MCPServer

### DIFF
--- a/asyncroscopy/mcp/mcp_server.py
+++ b/asyncroscopy/mcp/mcp_server.py
@@ -323,9 +323,9 @@ class MCPServer:
             
         else:
             # Scalars and standard arrays
-            def wrapper(**kwargs):
-                # Grab parameter name out of incoming kwargs, fallback to first positional item if needed
-                arg = kwargs.get(param_name)
+            def wrapper(*args, **kwargs):
+                # Get first positional arg or parameter name out of kwargs
+                arg = args[0] if args else kwargs.get(param_name)
                 result = func(arg)
                 return self._normalize_command_result(out_type, result)
 

--- a/asyncroscopy/mcp/mcp_server.py
+++ b/asyncroscopy/mcp/mcp_server.py
@@ -3,6 +3,7 @@
 import argparse
 import base64
 import inspect
+import re
 import json
 import traceback
 from pathlib import Path
@@ -260,6 +261,7 @@ class MCPServer:
         Returns:
             A wrapper function with a proper signature
         """
+
         in_type = cmd_info.in_type
         py_type = self._tango_type_to_python(in_type)
         in_desc = cmd_info.in_type_desc
@@ -278,33 +280,59 @@ class MCPServer:
             doc_lines.append(f"Output Description: {cmd_info.out_type_desc}")
         doc = "\n".join(doc_lines)
 
+        # Get parameter name from docstring description text
+        param_name = "arg"
+        if in_desc:
+            match = re.search(r'(?::param|@param)\s+(\w+):', in_desc)
+            if match:
+                param_name = match.group(1)
+                print(param_name)
+
         if in_desc and in_desc.lower() not in (
             "uninitialised",
             "none",
             "",
             "uninitialized",
         ):
-            # Sanitize description - remove newlines to prevent JSON schema breakage
+            # Sanitize description
             clean_desc = in_desc.replace("\n", " ").strip()
             arg_type = Annotated[py_type, Field(description=clean_desc)]
         else:
             arg_type = py_type
 
         if in_type == CmdArgType.DevVoid:
-
             def wrapper():
                 result = func()
                 return self._normalize_command_result(out_type, result)
 
             params = []
+            
+        elif py_type == dict:
+            # For commands taking a dictionary (like DevEncoded), allow arbitrary keyword arguments.
+            def wrapper(**kwargs):
+                if "arg" in kwargs and len(kwargs) == 1 and isinstance(kwargs["arg"], dict):
+                    arg_input = kwargs["arg"]
+                else:
+                    arg_input = kwargs
+                
+                result = func(arg_input)
+                return self._normalize_command_result(out_type, result)
+
+            # Use VAR_KEYWORD (**kwargs) to make Pydantic accept any incoming fields
+            params = [inspect.Parameter("kwargs", inspect.Parameter.VAR_KEYWORD)]
+            
         else:
-            def wrapper(arg):
+            # Scalars and standard arrays
+            def wrapper(**kwargs):
+                # Grab parameter name out of incoming kwargs, fallback to first positional item if needed
+                arg = kwargs.get(param_name)
                 result = func(arg)
                 return self._normalize_command_result(out_type, result)
 
-            params = [inspect.Parameter("arg", inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=arg_type)]
+            params = [inspect.Parameter(param_name, inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=arg_type)]
 
-        wrapper.__annotations__ = {p.name: p.annotation for p in params}
+        # Build annotations, omitting VAR_KEYWORD parameters so Pydantic safely allows dynamic extra fields
+        wrapper.__annotations__ = {p.name: p.annotation for p in params if p.kind != inspect.Parameter.VAR_KEYWORD}
         wrapper.__annotations__["return"] = py_return_type
 
         wrapper.__signature__ = inspect.Signature(parameters=params, return_annotation=py_return_type)
@@ -346,7 +374,7 @@ class MCPServer:
                 continue
 
             for cmd in commands:
-                command_name = cmd.cmd_name if hasattr(cmd, "cmd_name") else str(cmd)
+                command_name = cmd.cmd_name
                 global_blocks = self.blocked_functions.get("*", [])
                 if command_name in global_blocks or f"{dev_class}.{command_name}" in global_blocks or command_name in self.blocked_functions.get(dev_class, []):
                     continue

--- a/notebooks/11_Test_AI_Agent.ipynb
+++ b/notebooks/11_Test_AI_Agent.ipynb
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "76a9e540",
    "metadata": {},
    "outputs": [],
@@ -57,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "38070335",
    "metadata": {},
    "outputs": [
@@ -88,19 +88,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "8b0e9baa",
+   "metadata": {},
+   "source": [
+    "### Optionally filter tools to test a few at a time"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "475a8e82",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Filtered to 3 tool(s): ['get_data_from_key', 'list_devices', 'DigitalTwin_acquire_scanned_image']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "def filter_tools(tools: list[BaseTool], tool_names: list[str]) -> list[BaseTool]:\n",
     "    return [tool for tool in tools if tool.name in tool_names]\n",
@@ -161,13 +161,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "W0713 12:50:44.861000 50880 Lib\\site-packages\\torch\\utils\\flop_counter.py:29] triton not found; flop counting will not work for triton kernels\n"
+      "W0713 13:26:05.132000 9444 Lib\\site-packages\\torch\\utils\\flop_counter.py:29] triton not found; flop counting will not work for triton kernels\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "df1e867a901b469187c0965c240d475e",
+       "model_id": "890a459fe8684c239cff16175309941b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -307,7 +307,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "b50a2f06",
    "metadata": {},
    "outputs": [],
@@ -331,7 +331,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "3fd88186",
    "metadata": {},
    "outputs": [
@@ -341,13 +341,15 @@
      "text": [
       "Starting Local Agent...\n",
       "\n",
-      "I have access to the following tools:\n",
+      "I have access to a wide range of tools categorized by their Tango Device Classes. Here is a summary of the tools available to me:\n",
       "\n",
-      "1. **get_data_from_key**: Used to read a DATA/Tiled HDF5 acquisition key and return dataset metadata along with small previews.\n",
-      "2. **list_devices**: Used to list available devices, with the ability to filter by blocked classes.\n",
-      "3. **DigitalTwin_acquire_scanned_image**: A Tango Device Class tool used to acquire a scanned image based on a provided list of detectors.\n",
+      "**1. Digital Twin Control (`DigitalTwin`)**\n",
+      "- **Connectivity:** `DigitalTwin_Connect`, `DigitalTwin_Disconnect`, `DigitalTwin_State`, `DigitalTwin_Status`, `DigitalTwin_get_status`.\n",
+      "- **Acquisition:** `DigitalTwin_acquire_camera_image`, `DigitalTwin_acquire_flucam_image`, `DigitalTwin_acquire_scanned_image`, `DigitalTwin_acquire_spectrum`, `DigitalTwin_acquire_scanned_data_advanced`, `DigitalTwin_get_image_data_cached`.\n",
+      "- **Beam & Stage Control:** `DigitalTwin_move_stage`, `DigitalTwin_get_stage`, `DigitalTwin_place_beam`, `DigitalTwin_place_beam_list`, `DigitalTwin_blank_beam`, `DigitalTwin_unblank_beam`.\n",
+      "- **Optical/System Adjustments:** `DigitalTwin_auto_focus`, `DigitalTwin_set_fov`/`get_fov`, `DigitalTwin_set_defocus`/`get_defocus`, `DigitalTwin_\n",
       "\n",
-      "Final Answer: I have access to get_data_from_key, list_devices, and DigitalTwin_acquire_scanned_image.\n"
+      "Model responded with plain text instead of using a tool format.\n"
      ]
     }
    ],
@@ -366,90 +368,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "185af0a4",
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[transformers] Both `max_new_tokens` (=256) and `max_length`(=20) seem to have been set. `max_new_tokens` will take precedence. Please refer to the documentation for more information. (https://huggingface.co/docs/transformers/main/en/main_classes/text_generation)\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Starting Local Agent...\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\Users\\dpelaia\\Documents\\asyncroscopy-agent-version\\.venv\\Lib\\site-packages\\bitsandbytes\\backends\\cuda\\ops.py:468: FutureWarning: _check_is_size will be removed in a future PyTorch release along with guard_size_oblivious.     Use _check(i >= 0) instead.\n",
-      "  torch._check_is_size(blocksize)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\n",
       "Action: DigitalTwin_acquire_scanned_image\n",
       "Arguments: {\"detector_list\": [\"HAADF\"]}\n",
-      "[Executing Tool]: Calling DigitalTwin_acquire_scanned_image({'detector_list': ['HAADF']})...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[transformers] Both `max_new_tokens` (=256) and `max_length`(=20) seem to have been set. `max_new_tokens` will take precedence. Please refer to the documentation for more information. (https://huggingface.co/docs/transformers/main/en/main_classes/text_generation)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Tool Result]: [{'type': 'text', 'text': 'stem_image_HAADF_20260713T125220143987.h5', 'id': 'lc_07412b9c-26f5-4799-af7c-8af51188d30c'}]\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\Users\\dpelaia\\Documents\\asyncroscopy-agent-version\\.venv\\Lib\\site-packages\\bitsandbytes\\backends\\cuda\\ops.py:468: FutureWarning: _check_is_size will be removed in a future PyTorch release along with guard_size_oblivious.     Use _check(i >= 0) instead.\n",
-      "  torch._check_is_size(blocksize)\n",
-      "[transformers] Both `max_new_tokens` (=256) and `max_length`(=20) seem to have been set. `max_new_tokens` will take precedence. Please refer to the documentation for more information. (https://huggingface.co/docs/transformers/main/en/main_classes/text_generation)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "[Executing Tool]: Calling DigitalTwin_acquire_scanned_image({'detector_list': ['HAADF']})...\n",
+      "[Tool Result]: [{'type': 'text', 'text': 'stem_image_HAADF_20260713T132752058144.h5', 'id': 'lc_bf3782b5-437b-4d26-b30c-d3ec8e22c7f3'}]\n",
+      "\n",
       "Action: get_data_from_key\n",
-      "Arguments: {\"key\": \"stem_image_HAADF_20260713T125220143987.h5\"}\n",
-      "[Executing Tool]: Calling get_data_from_key({'key': 'stem_image_HAADF_20260713T125220143987.h5'})...\n",
-      "[Tool Result]: [{'type': 'text', 'text': '{\"key\":\"stem_image_HAADF_20260713T125220143987.h5\",\"path\":\"outputs\\\\\\\\tiled_acquisitions\\\\\\\\stem_image_HAADF_20260713T125220143987.h5\",\"size_bytes\":1054720,\"format\":\"hdf5\",\"attrs\":{},\"datasets\":[{\"name\":\"image/HAADF\",\"shape\":[512,512],\"dtype\":\"float32\",\"attrs\":{\"acquisition_type\":\"stem_image\",\"detector\":\"HAADF\"},\"preview\":[0.05876747891306877,0.059358369559049606,0.06118931993842125,0.06082397326827049,0.0564676932990551,0.04990082606673241,0.04418998211622238,0.03987928479909897,0.03610394150018692,0.035545140504837036,0.04252124950289726,0.05505423620343208,0.06561834365129471,0.07019422203302383,0.07148002833127975,0.07285333424806595,0.07347744703292847,0.07066406309604645,0.06401708722114563,0.056383710354566574,0.051454104483127594,0.05054553970694542,0.05208514258265495,0.0538441427052021,0.05422438308596611,0.05208098888397217,0.048500727862119675,0.047812726348638535,0.05187470465898514,0.05491768941283226,0.050811152905225754,0.043654605746269226,0.04326065629720688,0.05174452066421509,0.06194362789392471,0.06640271842479706,0.0635075569152832,0.05842627212405205,0.057888131588697433,0.06207282468676567,0.06557518988847733,0.06581702083349228,0.06478384137153625,0.06427361071109772,0.06426017731428146,0.06367012113332748,0.061079155653715134,0.05645532160997391,0.0517633855342865,0.0490812323987484,0.04833746701478958,0.047277651727199554,0.04368274658918381,0.03843152895569801,0.03658200800418854,0.04216315597295761,0.05241742357611656,0.060192059725522995,0.06063463166356087,0.05455124378204346,0.045965105295181274,0.0375676155090332,0.030386565253138542,0.026209501549601555]}]}', 'id': 'lc_8d379aaf-23cb-4ec5-8837-a7c83bea62bf'}]\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\Users\\dpelaia\\Documents\\asyncroscopy-agent-version\\.venv\\Lib\\site-packages\\bitsandbytes\\backends\\cuda\\ops.py:468: FutureWarning: _check_is_size will be removed in a future PyTorch release along with guard_size_oblivious.     Use _check(i >= 0) instead.\n",
-      "  torch._check_is_size(blocksize)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Final Answer: The HAADF scanned image has been successfully acquired and retrieved from the tiled server. The image is stored in the file `stem_image_HAADF_20260713T125220143987.h5` with a dataset named `image/HAADF` having a shape of [512, 512] and a data type of `float32`.\n"
+      "Arguments: {\"key\": \"stem_image_HAADF_20260713T132752058144.h5\"}\n",
+      "[Executing Tool]: Calling get_data_from_key({'key': 'stem_image_HAADF_20260713T132752058144.h5'})...\n",
+      "[Tool Result]: [{'type': 'text', 'text': '{\"key\":\"stem_image_HAADF_20260713T132752058144.h5\",\"path\":\"outputs\\\\\\\\tiled_acquisitions\\\\\\\\stem_image_HAADF_20260713T132752058144.h5\",\"size_bytes\":1054720,\"format\":\"hdf5\",\"attrs\":{},\"datasets\":[{\"name\":\"image/HAADF\",\"shape\":[512,512],\"dtype\":\"float32\",\"attrs\":{\"acquisition_type\":\"stem_image\",\"detector\":\"HAADF\"},\"preview\":[0.05876747891306877,0.059358369559049606,0.06118931993842125,0.06082397326827049,0.0564676932990551,0.04990082606673241,0.04418998211622238,0.03987928479909897,0.03610394150018692,0.035545140504837036,0.04252124950289726,0.05505423620343208,0.06561834365129471,0.07019422203302383,0.07148002833127975,0.07285333424806595,0.07347744703292847,0.07066406309604645,0.06401708722114563,0.056383710354566574,0.051454104483127594,0.05054553970694542,0.05208514258265495,0.0538441427052021,0.05422438308596611,0.05208098888397217,0.048500727862119675,0.047812726348638535,0.05187470465898514,0.05491768941283226,0.050811152905225754,0.043654605746269226,0.04326065629720688,0.05174452066421509,0.06194362789392471,0.06640271842479706,0.0635075569152832,0.05842627212405205,0.057888131588697433,0.06207282468676567,0.06557518988847733,0.06581702083349228,0.06478384137153625,0.06427361071109772,0.06426017731428146,0.06367012113332748,0.061079155653715134,0.05645532160997391,0.0517633855342865,0.0490812323987484,0.04833746701478958,0.047277651727199554,0.04368274658918381,0.03843152895569801,0.03658200800418854,0.04216315597295761,0.05241742357611656,0.060192059725522995,0.06063463166356087,0.05455124378204346,0.045965105295181274,0.0375676155090332,0.030386565253138542,0.026209501549601555]}]}', 'id': 'lc_355ccc11-36f5-4d61-a945-03bd0249ece2'}]\n",
+      "\n",
+      "Final Answer: The scanned image was successfully acquired via HAADF, resulting in the file `stem_image_HAADF_20260713T132752058144.h5`. Data retrieved from the tiled server shows the dataset `image/HAADF` with a shape of [512, 512] and a float32 data type.\n"
      ]
     }
    ],

--- a/notebooks/11_Test_AI_Agent.ipynb
+++ b/notebooks/11_Test_AI_Agent.ipynb
@@ -34,12 +34,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 1,
    "id": "76a9e540",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
     "from pprint import pprint\n",
     "\n",
     "from langchain.agents import create_agent\n",
@@ -58,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 2,
    "id": "38070335",
    "metadata": {},
    "outputs": [
@@ -90,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 3,
    "id": "475a8e82",
    "metadata": {},
    "outputs": [
@@ -98,7 +97,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Filtered to 2 tool(s): ['get_data_from_key', 'list_devices']\n"
+      "Filtered to 3 tool(s): ['get_data_from_key', 'list_devices', 'DigitalTwin_acquire_scanned_image']\n"
      ]
     }
    ],
@@ -107,7 +106,7 @@
     "    return [tool for tool in tools if tool.name in tool_names]\n",
     "\n",
     "# Filter the tools so we can test a few at a time\n",
-    "tools = filter_tools(tools, [\"list_devices\", \"AutoScriptMicroscope_acquire_scanned_image\", \"get_data_from_key\"])\n",
+    "tools = filter_tools(tools, [\"list_devices\", \"AutoScriptMicroscope_acquire_scanned_image\", \"DigitalTwin_acquire_scanned_image\", \"get_data_from_key\"])\n",
     "print(f\"Filtered to {len(tools)} tool(s): {[tool.name for tool in tools]}\")"
    ]
   },
@@ -145,7 +144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 4,
    "id": "8ed64650",
    "metadata": {},
    "outputs": [
@@ -162,13 +161,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "W0712 19:43:52.235000 36944 Lib\\site-packages\\torch\\utils\\flop_counter.py:29] triton not found; flop counting will not work for triton kernels\n"
+      "W0713 10:09:16.725000 45508 Lib\\site-packages\\torch\\utils\\flop_counter.py:29] triton not found; flop counting will not work for triton kernels\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c65e32e8874144309c1b1cbb967d40dc",
+       "model_id": "2ebd0431b23749ce8f5ac35538c1dcf0",
        "version_major": 2,
        "version_minor": 0
       },
@@ -236,20 +235,74 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 5,
    "id": "e7f9863c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "agent = create_agent(model, tools)\n",
+    "import json\n",
     "\n",
-    "def final_text(result):\n",
-    "    message = result[\"messages\"][-1]\n",
-    "    return getattr(message, \"content\", message)\n",
+    "async def run_agent_demo(user_prompt: str, tool_list: list[BaseTool], is_local_model: bool = False):\n",
+    "    # Format tool details into text so the local model can see them\n",
+    "    tools_string = \"\\n\".join([f\"- Name: {t.name}\\n  Description: {t.description}\\n\" for t in tool_list])\n",
+    "    \n",
+    "    agent_context = f\"\"\"You are an AI Agent with access to these tools:\n",
+    "    {tools_string}\n",
     "\n",
-    "def tool_calls(result):\n",
-    "    message = result[\"messages\"][-1]\n",
-    "    return getattr(message, \"tool_calls\", message)"
+    "    To use a tool, you MUST respond using this exact format:\n",
+    "    Action: <tool_name>\n",
+    "    Arguments: <JSON_object_or_string>\n",
+    "\n",
+    "    When you have the final answer, respond with:\n",
+    "    Final Answer: <your_response>\n",
+    "\n",
+    "    User Request: {user_prompt}\"\"\"\n",
+    "\n",
+    "    print(\"Starting Local Agent...\\n\")\n",
+    "    \n",
+    "    for step in range(5):\n",
+    "        if is_local_model:\n",
+    "            raw_response = model.invoke(agent_context).content\n",
+    "        else:\n",
+    "            raw_response = await model.ainvoke(agent_context)\n",
+    "        response = raw_response.replace(\"<turn|>\", \"\").strip()\n",
+    "        print(response)\n",
+    "        \n",
+    "        # Check if the model wants to call a tool\n",
+    "        if \"Action:\" in response and \"Arguments:\" in response:\n",
+    "            try:\n",
+    "                # Parse out the tool execution details\n",
+    "                tool_name = response.split(\"Action:\")[1].split(\"\\n\")[0].strip()\n",
+    "                tool_args_raw = response.split(\"Arguments:\")[1].split(\"\\n\")[0].strip()\n",
+    "                \n",
+    "                # Convert args to dict if it's JSON, otherwise keep as string\n",
+    "                try:\n",
+    "                    tool_args = json.loads(tool_args_raw)\n",
+    "                except json.JSONDecodeError:\n",
+    "                    tool_args = tool_args_raw\n",
+    "\n",
+    "                # Find the matching tool object from loaded MCP tools\n",
+    "                active_tool = next((t for t in tool_list if t.name == tool_name), None)\n",
+    "                \n",
+    "                if active_tool:\n",
+    "                    print(f\"[Executing Tool]: Calling {tool_name}({tool_args})...\")\n",
+    "                    observation = await active_tool.ainvoke(tool_args)\n",
+    "                    print(f\"[Tool Result]: {observation}\\n\")\n",
+    "                    \n",
+    "                    # Feed the observation back to the model's memory context\n",
+    "                    agent_context += f\"\\n{response}\\nObservation: {observation}\"\n",
+    "                else:\n",
+    "                    print(f\"Error: Model tried to call unknown tool '{tool_name}'\\n\")\n",
+    "                    break\n",
+    "            except Exception as e:\n",
+    "                print(f\"Parsing/Execution error: {e}\")\n",
+    "                break\n",
+    "                \n",
+    "        elif \"Final Answer:\" in response:\n",
+    "            break\n",
+    "        else:\n",
+    "            print(\"\\nModel responded with plain text instead of using a tool format.\")\n",
+    "            break"
    ]
   },
   {
@@ -262,7 +315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 6,
    "id": "3fd88186",
    "metadata": {},
    "outputs": [
@@ -270,35 +323,43 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[transformers] Both `max_new_tokens` (=256) and `max_length`(=20) seem to have been set. `max_new_tokens` will take precedence. Please refer to the documentation for more information. (https://huggingface.co/docs/transformers/main/en/main_classes/text_generation)\n",
-      "c:\\Users\\dpelaia\\Documents\\asyncroscopy-agent-version\\.venv\\Lib\\site-packages\\bitsandbytes\\backends\\cuda\\ops.py:468: FutureWarning: _check_is_size will be removed in a future PyTorch release along with guard_size_oblivious.     Use _check(i >= 0) instead.\n",
-      "  torch._check_is_size(blocksize)\n"
+      "[transformers] Both `max_new_tokens` (=256) and `max_length`(=20) seem to have been set. `max_new_tokens` will take precedence. Please refer to the documentation for more information. (https://huggingface.co/docs/transformers/main/en/main_classes/text_generation)\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "I do not have access to any tools, such as Google Search or external applications, by default. I can only use tools if specific definitions and endpoints are provided to me within the context of our conversation.<turn|>\n",
-      "[]\n"
+      "Starting Local Agent...\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\dpelaia\\Documents\\asyncroscopy-agent-version\\.venv\\Lib\\site-packages\\bitsandbytes\\backends\\cuda\\ops.py:468: FutureWarning: _check_is_size will be removed in a future PyTorch release along with guard_size_oblivious.     Use _check(i >= 0) instead.\n",
+      "  torch._check_is_size(blocksize)\n",
+      "[transformers] Ignoring clean_up_tokenization_spaces=True for BPE tokenizer GemmaTokenizer. The clean_up_tokenization post-processing step is designed for WordPiece tokenizers and is destructive for BPE (it strips spaces before punctuation). Set clean_up_tokenization_spaces=False to suppress this warning, or set clean_up_tokenization_spaces_for_bpe_even_though_it_will_corrupt_output=True to force cleanup anyway.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "I have access to the following tools:\n",
+      "\n",
+      "1. **get_data_from_key**: Used to read a DATA/Tiled HDF5 acquisition key and return dataset metadata along with small previews.\n",
+      "2. **list_devices**: Used to list available devices, with the ability to filter by blocked classes.\n",
+      "3. **DigitalTwin_acquire_scanned_image**: A Tango Device Class tool used to acquire a scanned image based on a provided list of detectors.\n",
+      "\n",
+      "Final Answer: I have access to the tools `get_data_from_key`, `list_devices`, and `DigitalTwin_acquire_scanned_image`.\n"
      ]
     }
    ],
    "source": [
     "prompt = \"What tools can you access?\"\n",
-    "\n",
-    "if not using_local_model:\n",
-    "    result = await agent.ainvoke({\n",
-    "        \"messages\": prompt\n",
-    "    })\n",
-    "else :\n",
-    "    result = agent.invoke(\n",
-    "        {\"messages\": prompt},\n",
-    "        config={\"configurable\": {\"use_async\": False}}\n",
-    "    )\n",
-    "\n",
-    "print(final_text(result))\n",
-    "print(tool_calls(result))"
+    "await run_agent_demo(prompt, tools, is_local_model=using_local_model)"
    ]
   },
   {
@@ -311,33 +372,102 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "185af0a4",
    "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[transformers] Both `max_new_tokens` (=256) and `max_length`(=20) seem to have been set. `max_new_tokens` will take precedence. Please refer to the documentation for more information. (https://huggingface.co/docs/transformers/main/en/main_classes/text_generation)\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The scanned image has been acquired via HAADF. The file path is: `stem_image_HAADF_20260706T141203062528.h5`\n"
+      "Starting Local Agent...\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\dpelaia\\Documents\\asyncroscopy-agent-version\\.venv\\Lib\\site-packages\\bitsandbytes\\backends\\cuda\\ops.py:468: FutureWarning: _check_is_size will be removed in a future PyTorch release along with guard_size_oblivious.     Use _check(i >= 0) instead.\n",
+      "  torch._check_is_size(blocksize)\n",
+      "[transformers] Both `max_new_tokens` (=256) and `max_length`(=20) seem to have been set. `max_new_tokens` will take precedence. Please refer to the documentation for more information. (https://huggingface.co/docs/transformers/main/en/main_classes/text_generation)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Action: DigitalTwin_acquire_scanned_image\n",
+      "Arguments: {\"detector_list\": [\"HAADF\"]}\n",
+      "[Executing Tool]: Calling DigitalTwin_acquire_scanned_image({'detector_list': ['HAADF']})...\n",
+      "[Tool Result]: [{'type': 'text', 'text': \"2 validation errors for call[DigitalTwin_acquire_scanned_image]\\narg\\n  Missing required argument [type=missing_argument, input_value={'detector_list': ['HAADF']}, input_type=dict]\\n    For further information visit https://errors.pydantic.dev/2.13/v/missing_argument\\ndetector_list\\n  Unexpected keyword argument [type=unexpected_keyword_argument, input_value=['HAADF'], input_type=list]\\n    For further information visit https://errors.pydantic.dev/2.13/v/unexpected_keyword_argument\", 'id': 'lc_98953b51-c29b-46f8-ae72-da384d3ee22f'}]\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\dpelaia\\Documents\\asyncroscopy-agent-version\\.venv\\Lib\\site-packages\\bitsandbytes\\backends\\cuda\\ops.py:468: FutureWarning: _check_is_size will be removed in a future PyTorch release along with guard_size_oblivious.     Use _check(i >= 0) instead.\n",
+      "  torch._check_is_size(blocksize)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Based on the error received, it appears the tool `DigitalTwin_acquire_scanned_image` expects a different argument structure than provided. The error indicates a missing required argument named `arg` and an unexpected keyword argument `detector_list`.\n",
+      "\n",
+      "Since the tool description specifies the input as a `DevVarStringArray` for `detector_list`, but the system rejected it as a keyword argument, I will attempt to pass the detector list within the `arg` parameter.\n",
+      "\n",
+      "Action: DigitalTwin_acquire_scanned_image\n",
+      "Arguments: {\"arg\": [\"HAADF\"]}\n",
+      "[Executing Tool]: Calling DigitalTwin_acquire_scanned_image({'arg': ['HAADF']})...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[transformers] Both `max_new_tokens` (=256) and `max_length`(=20) seem to have been set. `max_new_tokens` will take precedence. Please refer to the documentation for more information. (https://huggingface.co/docs/transformers/main/en/main_classes/text_generation)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[Tool Result]: [{'type': 'text', 'text': \"Error calling tool 'DigitalTwin_acquire_scanned_image': DevFailed[\\n    DevError[\\n        desc = TRANSIENT CORBA system exception: TRANSIENT_CallTimedout\\n        origin = Connection::command_inout()\\n        reason = API_CorbaException\\n        severity = ERR\\n    ],\\n    DevError[\\n        desc = Timeout (3000 mS) exceeded on device asyncroscopy/instrument/default, command acquire_scanned_image\\n        origin = Connection::command_inout()\\n        reason = API_DeviceTimedOut\\n        severity = ERR\\n    ]\\n]\", 'id': 'lc_1275022f-6f62-45df-a1e0-aa45c6ab2cbe'}]\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\dpelaia\\Documents\\asyncroscopy-agent-version\\.venv\\Lib\\site-packages\\bitsandbytes\\backends\\cuda\\ops.py:468: FutureWarning: _check_is_size will be removed in a future PyTorch release along with guard_size_oblivious.     Use _check(i >= 0) instead.\n",
+      "  torch._check_is_size(blocksize)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The attempt to acquire a scanned image via HAADF resulted in a timeout error (`TRANSIENT_CallTimedout`) from the device `asyncroscopy/instrument/default`. This indicates that the command was sent correctly to the hardware/simulator, but the device failed to respond within the allotted 3000ms window.\n",
+      "\n",
+      "Final Answer: I attempted to acquire the HAADF scanned image, but the request timed out on the device side (`asyncroscopy/instrument/default`). As a result, no file path could be retrieved.\n"
      ]
     }
    ],
    "source": [
     "prompt = \"Get a scanned image via HAADF and give me the full file path.\"\n",
-    "\n",
-    "if not using_local_model:\n",
-    "    result = await agent.ainvoke({\n",
-    "        \"messages\": prompt\n",
-    "    })\n",
-    "else :\n",
-    "    result = agent.invoke(\n",
-    "        {\"messages\": prompt},\n",
-    "        config={\"configurable\": {\"use_async\": False}}\n",
-    "    )\n",
-    "\n",
-    "print(final_text(result))\n",
-    "print(tool_calls(result))"
+    "await run_agent_demo(prompt, tools, is_local_model=using_local_model)"
    ]
   }
  ],

--- a/notebooks/11_Test_AI_Agent.ipynb
+++ b/notebooks/11_Test_AI_Agent.ipynb
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "id": "76a9e540",
    "metadata": {},
    "outputs": [],
@@ -57,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "id": "38070335",
    "metadata": {},
    "outputs": [
@@ -89,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "id": "475a8e82",
    "metadata": {},
    "outputs": [
@@ -144,7 +144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "id": "8ed64650",
    "metadata": {},
    "outputs": [
@@ -161,13 +161,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "W0713 10:14:19.166000 28936 Lib\\site-packages\\torch\\utils\\flop_counter.py:29] triton not found; flop counting will not work for triton kernels\n"
+      "W0713 12:50:44.861000 50880 Lib\\site-packages\\torch\\utils\\flop_counter.py:29] triton not found; flop counting will not work for triton kernels\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "78958e94068e4f2cabc7449e3d49264f",
+       "model_id": "df1e867a901b469187c0965c240d475e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -182,7 +182,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[transformers] Passing `generation_config` together with generation-related arguments=({'max_new_tokens', 'temperature'}) is deprecated and will be removed in future versions. Please pass either a `generation_config` object OR all generation parameters explicitly, but not both.\n"
+      "[transformers] Passing `generation_config` together with generation-related arguments=({'temperature', 'max_new_tokens'}) is deprecated and will be removed in future versions. Please pass either a `generation_config` object OR all generation parameters explicitly, but not both.\n"
      ]
     }
    ],
@@ -235,7 +235,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "id": "e7f9863c",
    "metadata": {},
    "outputs": [],
@@ -307,7 +307,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 6,
    "id": "b50a2f06",
    "metadata": {},
    "outputs": [],
@@ -331,7 +331,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 7,
    "id": "3fd88186",
    "metadata": {},
    "outputs": [
@@ -366,7 +366,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 8,
    "id": "185af0a4",
    "metadata": {},
    "outputs": [
@@ -389,7 +389,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[transformers] Both `max_new_tokens` (=256) and `max_length`(=20) seem to have been set. `max_new_tokens` will take precedence. Please refer to the documentation for more information. (https://huggingface.co/docs/transformers/main/en/main_classes/text_generation)\n"
+      "c:\\Users\\dpelaia\\Documents\\asyncroscopy-agent-version\\.venv\\Lib\\site-packages\\bitsandbytes\\backends\\cuda\\ops.py:468: FutureWarning: _check_is_size will be removed in a future PyTorch release along with guard_size_oblivious.     Use _check(i >= 0) instead.\n",
+      "  torch._check_is_size(blocksize)\n"
      ]
     },
     {
@@ -398,16 +399,7 @@
      "text": [
       "Action: DigitalTwin_acquire_scanned_image\n",
       "Arguments: {\"detector_list\": [\"HAADF\"]}\n",
-      "[Executing Tool]: Calling DigitalTwin_acquire_scanned_image({'detector_list': ['HAADF']})...\n",
-      "[Tool Result]: [{'type': 'text', 'text': \"2 validation errors for call[DigitalTwin_acquire_scanned_image]\\narg\\n  Missing required argument [type=missing_argument, input_value={'detector_list': ['HAADF']}, input_type=dict]\\n    For further information visit https://errors.pydantic.dev/2.13/v/missing_argument\\ndetector_list\\n  Unexpected keyword argument [type=unexpected_keyword_argument, input_value=['HAADF'], input_type=list]\\n    For further information visit https://errors.pydantic.dev/2.13/v/unexpected_keyword_argument\", 'id': 'lc_19b7bd04-6c11-4cca-a579-0790b8d0a0de'}]\n",
-      "\n",
-      "Based on the error received, it appears the tool `DigitalTwin_acquire_scanned_image` expects a different argument structure than the one provided. The error indicates that a required argument named `arg` is missing and that `detector_list` is an unexpected keyword argument.\n",
-      "\n",
-      "Since the tool description specifies the input as a `DevVarStringArray` for `detector_list`, but the system is rejecting it as a keyword argument, I will attempt to pass the detector list within the `arg` parameter.\n",
-      "\n",
-      "Action: DigitalTwin_acquire_scanned_image\n",
-      "Arguments: {\"arg\": [\"HAADF\"]}\n",
-      "[Executing Tool]: Calling DigitalTwin_acquire_scanned_image({'arg': ['HAADF']})...\n"
+      "[Executing Tool]: Calling DigitalTwin_acquire_scanned_image({'detector_list': ['HAADF']})...\n"
      ]
     },
     {
@@ -421,14 +413,48 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[Tool Result]: [{'type': 'text', 'text': 'stem_image_HAADF_20260713T101811907333.h5', 'id': 'lc_a975e503-3998-4113-a902-2adee6819ada'}]\n",
-      "\n",
-      "Final Answer: The scanned image via HAADF has been acquired, and the full file path is stem_image_HAADF_20260713T101811907333.h5.\n"
+      "[Tool Result]: [{'type': 'text', 'text': 'stem_image_HAADF_20260713T125220143987.h5', 'id': 'lc_07412b9c-26f5-4799-af7c-8af51188d30c'}]\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\dpelaia\\Documents\\asyncroscopy-agent-version\\.venv\\Lib\\site-packages\\bitsandbytes\\backends\\cuda\\ops.py:468: FutureWarning: _check_is_size will be removed in a future PyTorch release along with guard_size_oblivious.     Use _check(i >= 0) instead.\n",
+      "  torch._check_is_size(blocksize)\n",
+      "[transformers] Both `max_new_tokens` (=256) and `max_length`(=20) seem to have been set. `max_new_tokens` will take precedence. Please refer to the documentation for more information. (https://huggingface.co/docs/transformers/main/en/main_classes/text_generation)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Action: get_data_from_key\n",
+      "Arguments: {\"key\": \"stem_image_HAADF_20260713T125220143987.h5\"}\n",
+      "[Executing Tool]: Calling get_data_from_key({'key': 'stem_image_HAADF_20260713T125220143987.h5'})...\n",
+      "[Tool Result]: [{'type': 'text', 'text': '{\"key\":\"stem_image_HAADF_20260713T125220143987.h5\",\"path\":\"outputs\\\\\\\\tiled_acquisitions\\\\\\\\stem_image_HAADF_20260713T125220143987.h5\",\"size_bytes\":1054720,\"format\":\"hdf5\",\"attrs\":{},\"datasets\":[{\"name\":\"image/HAADF\",\"shape\":[512,512],\"dtype\":\"float32\",\"attrs\":{\"acquisition_type\":\"stem_image\",\"detector\":\"HAADF\"},\"preview\":[0.05876747891306877,0.059358369559049606,0.06118931993842125,0.06082397326827049,0.0564676932990551,0.04990082606673241,0.04418998211622238,0.03987928479909897,0.03610394150018692,0.035545140504837036,0.04252124950289726,0.05505423620343208,0.06561834365129471,0.07019422203302383,0.07148002833127975,0.07285333424806595,0.07347744703292847,0.07066406309604645,0.06401708722114563,0.056383710354566574,0.051454104483127594,0.05054553970694542,0.05208514258265495,0.0538441427052021,0.05422438308596611,0.05208098888397217,0.048500727862119675,0.047812726348638535,0.05187470465898514,0.05491768941283226,0.050811152905225754,0.043654605746269226,0.04326065629720688,0.05174452066421509,0.06194362789392471,0.06640271842479706,0.0635075569152832,0.05842627212405205,0.057888131588697433,0.06207282468676567,0.06557518988847733,0.06581702083349228,0.06478384137153625,0.06427361071109772,0.06426017731428146,0.06367012113332748,0.061079155653715134,0.05645532160997391,0.0517633855342865,0.0490812323987484,0.04833746701478958,0.047277651727199554,0.04368274658918381,0.03843152895569801,0.03658200800418854,0.04216315597295761,0.05241742357611656,0.060192059725522995,0.06063463166356087,0.05455124378204346,0.045965105295181274,0.0375676155090332,0.030386565253138542,0.026209501549601555]}]}', 'id': 'lc_8d379aaf-23cb-4ec5-8837-a7c83bea62bf'}]\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\dpelaia\\Documents\\asyncroscopy-agent-version\\.venv\\Lib\\site-packages\\bitsandbytes\\backends\\cuda\\ops.py:468: FutureWarning: _check_is_size will be removed in a future PyTorch release along with guard_size_oblivious.     Use _check(i >= 0) instead.\n",
+      "  torch._check_is_size(blocksize)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Final Answer: The HAADF scanned image has been successfully acquired and retrieved from the tiled server. The image is stored in the file `stem_image_HAADF_20260713T125220143987.h5` with a dataset named `image/HAADF` having a shape of [512, 512] and a data type of `float32`.\n"
      ]
     }
    ],
    "source": [
-    "prompt = \"Get a scanned image via HAADF and give me the full file path.\"\n",
+    "prompt = \"Get a scanned image via HAADF and get it from the tiled server.\"\n",
     "await run_agent_demo(prompt, tools, is_local_model=using_local_model)"
    ]
   }

--- a/notebooks/11_Test_AI_Agent.ipynb
+++ b/notebooks/11_Test_AI_Agent.ipynb
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 27,
    "id": "76a9e540",
    "metadata": {},
    "outputs": [],
@@ -58,7 +58,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 30,
    "id": "38070335",
    "metadata": {},
    "outputs": [
@@ -66,13 +66,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Loaded 60 tool(s)\n",
-      "['get_data_from_key', 'list_devices', 'CAMERA_State', 'CAMERA_Status', 'CORRECTOR_State', 'CORRECTOR_Status', 'CORRECTOR_acquire_tableau', 'CORRECTOR_correct_aberration', 'CORRECTOR_get_aberrations_coeff_sim', 'CORRECTOR_get_info', 'CORRECTOR_measure_c1a1', 'CORRECTOR_reconnect', 'CORRECTOR_set_aberrations_coeff_sim', 'DATA_State', 'DATA_Status', 'DATA_configure', 'DATA_get_config', 'DATA_register_path', 'DATA_register_save_path', 'DATA_start_tiled_server', 'DATA_stop_tiled_server', 'EDS_State', 'EDS_Status', 'FLUCAM_State', 'FLUCAM_Status', 'AutoScriptMicroscope_Connect', 'AutoScriptMicroscope_Disconnect', 'AutoScriptMicroscope_State', 'AutoScriptMicroscope_Status', 'AutoScriptMicroscope_acquire_camera_image', 'AutoScriptMicroscope_acquire_flucam_image', 'AutoScriptMicroscope_acquire_scanned_data_advanced', 'AutoScriptMicroscope_acquire_scanned_image', 'AutoScriptMicroscope_acquire_spectrum', 'AutoScriptMicroscope_auto_focus', 'AutoScriptMicroscope_blank_beam', 'AutoScriptMicroscope_calibrate_screen_current', 'AutoScriptMicroscope_get_beam_tilt', 'AutoScriptMicroscope_get_defocus', 'AutoScriptMicroscope_get_fov', 'AutoScriptMicroscope_get_image_data_cached', 'AutoScriptMicroscope_get_image_shift', 'AutoScriptMicroscope_get_screen_current', 'AutoScriptMicroscope_get_stage', 'AutoScriptMicroscope_get_status', 'AutoScriptMicroscope_move_stage', 'AutoScriptMicroscope_place_beam', 'AutoScriptMicroscope_place_beam_list', 'AutoScriptMicroscope_register_stage', 'AutoScriptMicroscope_set_beam_tilt', 'AutoScriptMicroscope_set_column_valves', 'AutoScriptMicroscope_set_defocus', 'AutoScriptMicroscope_set_fov', 'AutoScriptMicroscope_set_image_shift', 'AutoScriptMicroscope_set_screen_current', 'AutoScriptMicroscope_unblank_beam', 'SCAN_State', 'SCAN_Status', 'STAGE_State', 'STAGE_Status']\n"
+      "Loaded 52 tool(s)\n",
+      "['get_data_from_key', 'list_devices', 'CAMERA_State', 'CAMERA_Status', 'DATA_State', 'DATA_Status', 'DATA_configure', 'DATA_get_config', 'DATA_register_path', 'DATA_register_save_path', 'DATA_start_tiled_server', 'DATA_stop_tiled_server', 'EDS_State', 'EDS_Status', 'FLUCAM_State', 'FLUCAM_Status', 'DigitalTwin_Connect', 'DigitalTwin_Disconnect', 'DigitalTwin_State', 'DigitalTwin_Status', 'DigitalTwin_acquire_camera_image', 'DigitalTwin_acquire_flucam_image', 'DigitalTwin_acquire_scanned_data_advanced', 'DigitalTwin_acquire_scanned_image', 'DigitalTwin_acquire_spectrum', 'DigitalTwin_auto_focus', 'DigitalTwin_blank_beam', 'DigitalTwin_calibrate_screen_current', 'DigitalTwin_get_beam_tilt', 'DigitalTwin_get_defocus', 'DigitalTwin_get_diffraction_shift', 'DigitalTwin_get_fov', 'DigitalTwin_get_image_data_cached', 'DigitalTwin_get_image_shift', 'DigitalTwin_get_screen_current', 'DigitalTwin_get_stage', 'DigitalTwin_get_status', 'DigitalTwin_move_stage', 'DigitalTwin_place_beam', 'DigitalTwin_place_beam_list', 'DigitalTwin_set_beam_tilt', 'DigitalTwin_set_column_valves', 'DigitalTwin_set_defocus', 'DigitalTwin_set_diffraction_shift', 'DigitalTwin_set_fov', 'DigitalTwin_set_image_shift', 'DigitalTwin_set_screen_current', 'DigitalTwin_unblank_beam', 'SCAN_State', 'SCAN_Status', 'STAGE_State', 'STAGE_Status']\n"
      ]
     }
    ],
    "source": [
-    "MCP_URL = \"http://127.0.0.1:8095/mcp\"\n",
+    "MCP_URL = \"http://127.0.0.1:8000/mcp\"\n",
     "\n",
     "client = MultiServerMCPClient(\n",
     "    {\n",
@@ -90,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 31,
    "id": "475a8e82",
    "metadata": {},
    "outputs": [
@@ -98,7 +98,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Filtered to 2 tool(s): ['list_devices', 'AutoScriptMicroscope_acquire_scanned_image']\n"
+      "Filtered to 2 tool(s): ['get_data_from_key', 'list_devices']\n"
      ]
     }
    ],
@@ -145,14 +145,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 32,
    "id": "8ed64650",
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CUDA Available: True\n",
+      "Device Count: 1\n",
+      "Current Device: NVIDIA GeForce RTX 5090\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "W0712 19:43:52.235000 36944 Lib\\site-packages\\torch\\utils\\flop_counter.py:29] triton not found; flop counting will not work for triton kernels\n"
+     ]
+    },
+    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b8154b9351b14719ab8ab0645d35e77a",
+       "model_id": "c65e32e8874144309c1b1cbb967d40dc",
        "version_major": 2,
        "version_minor": 0
       },
@@ -176,6 +192,11 @@
     "from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline, BitsAndBytesConfig\n",
     "from langchain_huggingface import ChatHuggingFace, HuggingFacePipeline\n",
     "\n",
+    "print(\"CUDA Available:\", torch.cuda.is_available())\n",
+    "print(\"Device Count:\", torch.cuda.device_count())\n",
+    "if torch.cuda.is_available():\n",
+    "    print(\"Current Device:\", torch.cuda.get_device_name(0))\n",
+    "    \n",
     "HF_MODEL_ID = r\"C:\\Users\\Public\\Desktop\\Agents\\Gemma4-31B\"\n",
     "\n",
     "quantization_config = BitsAndBytesConfig(\n",
@@ -215,7 +236,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 33,
    "id": "e7f9863c",
    "metadata": {},
    "outputs": [],
@@ -241,21 +262,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "id": "3fd88186",
    "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[transformers] Both `max_new_tokens` (=256) and `max_length`(=20) seem to have been set. `max_new_tokens` will take precedence. Please refer to the documentation for more information. (https://huggingface.co/docs/transformers/main/en/main_classes/text_generation)\n",
+      "c:\\Users\\dpelaia\\Documents\\asyncroscopy-agent-version\\.venv\\Lib\\site-packages\\bitsandbytes\\backends\\cuda\\ops.py:468: FutureWarning: _check_is_size will be removed in a future PyTorch release along with guard_size_oblivious.     Use _check(i >= 0) instead.\n",
+      "  torch._check_is_size(blocksize)\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The available devices are asyncroscopy/camera/default, asyncroscopy/corrector/default, asyncroscopy/data/default, asyncroscopy/eds/default, asyncroscopy/flucam/default, asyncroscopy/instrument/default, asyncroscopy/scan/default, and asyncroscopy/stage/default.\n",
+      "I do not have access to any tools, such as Google Search or external applications, by default. I can only use tools if specific definitions and endpoints are provided to me within the context of our conversation.<turn|>\n",
       "[]\n"
      ]
     }
    ],
    "source": [
-    "prompt = \"List the available devices with the tool in one short sentence, then stop.\"\n",
+    "prompt = \"What tools can you access?\"\n",
     "\n",
     "if not using_local_model:\n",
     "    result = await agent.ainvoke({\n",

--- a/notebooks/11_Test_AI_Agent.ipynb
+++ b/notebooks/11_Test_AI_Agent.ipynb
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 4,
    "id": "76a9e540",
    "metadata": {},
    "outputs": [],
@@ -57,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 5,
    "id": "38070335",
    "metadata": {},
    "outputs": [
@@ -89,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 6,
    "id": "475a8e82",
    "metadata": {},
    "outputs": [
@@ -144,7 +144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 7,
    "id": "8ed64650",
    "metadata": {},
    "outputs": [
@@ -161,13 +161,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "W0713 10:09:16.725000 45508 Lib\\site-packages\\torch\\utils\\flop_counter.py:29] triton not found; flop counting will not work for triton kernels\n"
+      "W0713 10:14:19.166000 28936 Lib\\site-packages\\torch\\utils\\flop_counter.py:29] triton not found; flop counting will not work for triton kernels\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2ebd0431b23749ce8f5ac35538c1dcf0",
+       "model_id": "78958e94068e4f2cabc7449e3d49264f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -235,7 +235,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 8,
    "id": "e7f9863c",
    "metadata": {},
    "outputs": [],
@@ -306,6 +306,22 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "b50a2f06",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "import transformers.utils.logging as logging\n",
+    "from warnings import simplefilter\n",
+    "\n",
+    "# Ignore harmless FutureWarnings and transformers warnings\n",
+    "simplefilter(action='ignore', category=FutureWarning)\n",
+    "logging.set_verbosity_error()"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "a5aeea46",
    "metadata": {},
@@ -315,45 +331,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 14,
    "id": "3fd88186",
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[transformers] Both `max_new_tokens` (=256) and `max_length`(=20) seem to have been set. `max_new_tokens` will take precedence. Please refer to the documentation for more information. (https://huggingface.co/docs/transformers/main/en/main_classes/text_generation)\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Starting Local Agent...\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\Users\\dpelaia\\Documents\\asyncroscopy-agent-version\\.venv\\Lib\\site-packages\\bitsandbytes\\backends\\cuda\\ops.py:468: FutureWarning: _check_is_size will be removed in a future PyTorch release along with guard_size_oblivious.     Use _check(i >= 0) instead.\n",
-      "  torch._check_is_size(blocksize)\n",
-      "[transformers] Ignoring clean_up_tokenization_spaces=True for BPE tokenizer GemmaTokenizer. The clean_up_tokenization post-processing step is designed for WordPiece tokenizers and is destructive for BPE (it strips spaces before punctuation). Set clean_up_tokenization_spaces=False to suppress this warning, or set clean_up_tokenization_spaces_for_bpe_even_though_it_will_corrupt_output=True to force cleanup anyway.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "\n",
       "I have access to the following tools:\n",
       "\n",
       "1. **get_data_from_key**: Used to read a DATA/Tiled HDF5 acquisition key and return dataset metadata along with small previews.\n",
       "2. **list_devices**: Used to list available devices, with the ability to filter by blocked classes.\n",
       "3. **DigitalTwin_acquire_scanned_image**: A Tango Device Class tool used to acquire a scanned image based on a provided list of detectors.\n",
       "\n",
-      "Final Answer: I have access to the tools `get_data_from_key`, `list_devices`, and `DigitalTwin_acquire_scanned_image`.\n"
+      "Final Answer: I have access to get_data_from_key, list_devices, and DigitalTwin_acquire_scanned_image.\n"
      ]
     }
    ],
@@ -372,7 +366,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 15,
    "id": "185af0a4",
    "metadata": {},
    "outputs": [
@@ -395,8 +389,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "c:\\Users\\dpelaia\\Documents\\asyncroscopy-agent-version\\.venv\\Lib\\site-packages\\bitsandbytes\\backends\\cuda\\ops.py:468: FutureWarning: _check_is_size will be removed in a future PyTorch release along with guard_size_oblivious.     Use _check(i >= 0) instead.\n",
-      "  torch._check_is_size(blocksize)\n",
       "[transformers] Both `max_new_tokens` (=256) and `max_length`(=20) seem to have been set. `max_new_tokens` will take precedence. Please refer to the documentation for more information. (https://huggingface.co/docs/transformers/main/en/main_classes/text_generation)\n"
      ]
     },
@@ -407,25 +399,11 @@
       "Action: DigitalTwin_acquire_scanned_image\n",
       "Arguments: {\"detector_list\": [\"HAADF\"]}\n",
       "[Executing Tool]: Calling DigitalTwin_acquire_scanned_image({'detector_list': ['HAADF']})...\n",
-      "[Tool Result]: [{'type': 'text', 'text': \"2 validation errors for call[DigitalTwin_acquire_scanned_image]\\narg\\n  Missing required argument [type=missing_argument, input_value={'detector_list': ['HAADF']}, input_type=dict]\\n    For further information visit https://errors.pydantic.dev/2.13/v/missing_argument\\ndetector_list\\n  Unexpected keyword argument [type=unexpected_keyword_argument, input_value=['HAADF'], input_type=list]\\n    For further information visit https://errors.pydantic.dev/2.13/v/unexpected_keyword_argument\", 'id': 'lc_98953b51-c29b-46f8-ae72-da384d3ee22f'}]\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\Users\\dpelaia\\Documents\\asyncroscopy-agent-version\\.venv\\Lib\\site-packages\\bitsandbytes\\backends\\cuda\\ops.py:468: FutureWarning: _check_is_size will be removed in a future PyTorch release along with guard_size_oblivious.     Use _check(i >= 0) instead.\n",
-      "  torch._check_is_size(blocksize)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Based on the error received, it appears the tool `DigitalTwin_acquire_scanned_image` expects a different argument structure than provided. The error indicates a missing required argument named `arg` and an unexpected keyword argument `detector_list`.\n",
+      "[Tool Result]: [{'type': 'text', 'text': \"2 validation errors for call[DigitalTwin_acquire_scanned_image]\\narg\\n  Missing required argument [type=missing_argument, input_value={'detector_list': ['HAADF']}, input_type=dict]\\n    For further information visit https://errors.pydantic.dev/2.13/v/missing_argument\\ndetector_list\\n  Unexpected keyword argument [type=unexpected_keyword_argument, input_value=['HAADF'], input_type=list]\\n    For further information visit https://errors.pydantic.dev/2.13/v/unexpected_keyword_argument\", 'id': 'lc_19b7bd04-6c11-4cca-a579-0790b8d0a0de'}]\n",
       "\n",
-      "Since the tool description specifies the input as a `DevVarStringArray` for `detector_list`, but the system rejected it as a keyword argument, I will attempt to pass the detector list within the `arg` parameter.\n",
+      "Based on the error received, it appears the tool `DigitalTwin_acquire_scanned_image` expects a different argument structure than the one provided. The error indicates that a required argument named `arg` is missing and that `detector_list` is an unexpected keyword argument.\n",
+      "\n",
+      "Since the tool description specifies the input as a `DevVarStringArray` for `detector_list`, but the system is rejecting it as a keyword argument, I will attempt to pass the detector list within the `arg` parameter.\n",
       "\n",
       "Action: DigitalTwin_acquire_scanned_image\n",
       "Arguments: {\"arg\": [\"HAADF\"]}\n",
@@ -443,25 +421,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[Tool Result]: [{'type': 'text', 'text': \"Error calling tool 'DigitalTwin_acquire_scanned_image': DevFailed[\\n    DevError[\\n        desc = TRANSIENT CORBA system exception: TRANSIENT_CallTimedout\\n        origin = Connection::command_inout()\\n        reason = API_CorbaException\\n        severity = ERR\\n    ],\\n    DevError[\\n        desc = Timeout (3000 mS) exceeded on device asyncroscopy/instrument/default, command acquire_scanned_image\\n        origin = Connection::command_inout()\\n        reason = API_DeviceTimedOut\\n        severity = ERR\\n    ]\\n]\", 'id': 'lc_1275022f-6f62-45df-a1e0-aa45c6ab2cbe'}]\n",
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\Users\\dpelaia\\Documents\\asyncroscopy-agent-version\\.venv\\Lib\\site-packages\\bitsandbytes\\backends\\cuda\\ops.py:468: FutureWarning: _check_is_size will be removed in a future PyTorch release along with guard_size_oblivious.     Use _check(i >= 0) instead.\n",
-      "  torch._check_is_size(blocksize)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The attempt to acquire a scanned image via HAADF resulted in a timeout error (`TRANSIENT_CallTimedout`) from the device `asyncroscopy/instrument/default`. This indicates that the command was sent correctly to the hardware/simulator, but the device failed to respond within the allotted 3000ms window.\n",
+      "[Tool Result]: [{'type': 'text', 'text': 'stem_image_HAADF_20260713T101811907333.h5', 'id': 'lc_a975e503-3998-4113-a902-2adee6819ada'}]\n",
       "\n",
-      "Final Answer: I attempted to acquire the HAADF scanned image, but the request timed out on the device side (`asyncroscopy/instrument/default`). As a result, no file path could be retrieved.\n"
+      "Final Answer: The scanned image via HAADF has been acquired, and the full file path is stem_image_HAADF_20260713T101811907333.h5.\n"
      ]
     }
    ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,3 +81,14 @@ autoscript-tem-microscope-client = { path = "stubs/AutoScript_v_1.17/autoscript_
 autoscript-tem-toolkit = { path = "stubs/AutoScript_v_1.17/autoscript_tem_toolkit-1.17.0-py3-none-any.whl" }
 thermoscientific-logging = { path = "stubs/AutoScript_v_1.17/thermoscientific_logging-1.3.0-py3-none-any.whl" }
 pyjem = { path = "stubs/PyJEM_v_1.3.0.3564/PyJEM-1.3.0.3564-py3-none-any.whl" }
+torch = [
+    { index = "pytorch-cu128", marker = "sys_platform == 'win32'" }
+]
+torchvision = [
+    { index = "pytorch-cu128", marker = "sys_platform == 'win32'" }
+]
+
+[[tool.uv.index]]
+name = "pytorch-cu128"
+url = "https://download.pytorch.org/whl/cu128"
+explicit = true

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -458,7 +458,6 @@ class TestMCPServerTypeMapping:
 class TestMCPToolInvocation:
     def test_wrapper_supports_positional_and_keyword(self, monkeypatch) -> None:
         # Mock Database and DeviceProxy to avoid connection errors
-        # Must patch where it is used (imported)
         monkeypatch.setattr("asyncroscopy.mcp.mcp_server.Database", lambda host, port: None)
 
         # Mock objects for wrapping
@@ -471,7 +470,7 @@ class TestMCPToolInvocation:
             {
                 "in_type": tango.CmdArgType.DevString,
                 "out_type": tango.CmdArgType.DevString,
-                "in_type_desc": "some string",
+                "in_type_desc": ":param config_json: (not documented)\n:type config_json: DevString",
                 "out_type_desc": "result",
             },
         )
@@ -486,8 +485,8 @@ class TestMCPToolInvocation:
         import inspect
 
         sig = inspect.signature(wrapper)
-        param_name = list(sig.parameters.keys())[0]
-        assert param_name == "arg"
+        param_name = list(sig.parameters.keys())[0]        
+        assert param_name == "config_json" 
         assert wrapper(**{param_name: "world"}) == "world"
 
     def test_void_wrapper_supports_no_args(self, monkeypatch) -> None:


### PR DESCRIPTION
**MCP class:**
* Extract real parameter names in `_create_wrapper` so that LLMs can now call tools normally, supporting both positional and keyword arguments
* Updated tests accordingly

**Agent notebook**
* Built new agent init to handle tool calls manually
* Updated `pyproject.toml` `torch` requirments to use the correct version of CUDA for our local model to run